### PR TITLE
ci: add setup-node for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,10 @@ jobs:
       - name: Validate
         id: validate
         run: bun run validate
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@v4
+        with:
+          registry-url: 'https://registry.npmjs.org'
       - name: Release
         uses: TrigenSoftware/simple-release-action@v1
         with:


### PR DESCRIPTION
## Summary

- Adds `actions/setup-node@v4` with `registry-url: 'https://registry.npmjs.org'` to the `release` job, immediately before the `simple-release-action` publish step
- Without this step, npm has no `.npmrc` configured and cannot exchange the GitHub OIDC token for a publish token, causing `ENEEDAUTH`
- `id-token: write` was already set; this was the only missing piece for trusted publishing to work

## Test plan

- [ ] Merge into `main` and verify the release workflow completes without `ENEEDAUTH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)