### PR TITLE
fix: move bundled deps to devDependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,23 +4,21 @@
   "workspaces": {
     "": {
       "name": "dasolve",
-      "dependencies": {
-        "@commander-js/extra-typings": "14.0.0",
-        "@modelcontextprotocol/sdk": "1.26.0",
-        "inquirer": "12.9.4",
-        "zod": "4.3.6",
-      },
       "devDependencies": {
+        "@commander-js/extra-typings": "14.0.0",
         "@commitlint/cli": "19.8.1",
         "@commitlint/config-conventional": "19.8.1",
         "@commitlint/cz-commitlint": "19.8.1",
+        "@modelcontextprotocol/sdk": "1.26.0",
         "@simple-release/npm": "2.3.0",
         "@types/bun": "1.3.9",
         "commitizen": "4.3.1",
         "conventional-changelog": "7.1.1",
         "conventional-changelog-angular": "8.0.0",
+        "inquirer": "12.9.4",
         "oxlint": "1.14.0",
         "prettier": "3.6.2",
+        "zod": "4.3.6",
       },
       "optionalDependencies": {
         "archgate-darwin-arm64": ">=0.1.1",

--- a/package.json
+++ b/package.json
@@ -50,23 +50,21 @@
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0"
   },
   "type": "module",
-  "dependencies": {
-    "@commander-js/extra-typings": "14.0.0",
-    "@modelcontextprotocol/sdk": "1.26.0",
-    "inquirer": "12.9.4",
-    "zod": "4.3.6"
-  },
   "devDependencies": {
+    "@commander-js/extra-typings": "14.0.0",
     "@commitlint/cli": "19.8.1",
     "@commitlint/config-conventional": "19.8.1",
     "@commitlint/cz-commitlint": "19.8.1",
+    "@modelcontextprotocol/sdk": "1.26.0",
     "@simple-release/npm": "2.3.0",
     "@types/bun": "1.3.9",
     "commitizen": "4.3.1",
     "conventional-changelog": "7.1.1",
     "conventional-changelog-angular": "8.0.0",
+    "inquirer": "12.9.4",
     "oxlint": "1.14.0",
-    "prettier": "3.6.2"
+    "prettier": "3.6.2",
+    "zod": "4.3.6"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/src/engine/loader.ts
+++ b/src/engine/loader.ts
@@ -2,7 +2,23 @@ import { readdirSync } from "node:fs";
 import { join, basename } from "node:path";
 import { parseAdr } from "../formats/adr";
 import type { AdrDocument } from "../formats/adr";
-import { RuleSetSchema, type RuleSet } from "../formats/rules";
+import { type RuleSet } from "../formats/rules";
+import { z } from "zod";
+import type { RuleContext } from "../formats/rules";
+
+const RuleSetSchema = z.object({
+  rules: z.record(
+    z.string(),
+    z.object({
+      description: z.string(),
+      severity: z.enum(["error", "warning", "info"]).optional(),
+      check: z.custom<(ctx: RuleContext) => Promise<void>>(
+        (val) => typeof val === "function",
+        "Expected a function"
+      ),
+    })
+  ),
+});
 import { projectPaths } from "../helpers/paths";
 import { logDebug, logWarn } from "../helpers/log";
 

--- a/src/formats/rules.ts
+++ b/src/formats/rules.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 // --- Severity ---
 
 export type Severity = "error" | "warning" | "info";
@@ -62,20 +60,6 @@ export interface RuleConfig {
 export type RuleSet = {
   rules: Record<string, RuleConfig>;
 };
-
-export const RuleSetSchema = z.object({
-  rules: z.record(
-    z.string(),
-    z.object({
-      description: z.string(),
-      severity: z.enum(["error", "warning", "info"]).optional(),
-      check: z.custom<(ctx: RuleContext) => Promise<void>>(
-        (val) => typeof val === "function",
-        "Expected a function"
-      ),
-    })
-  ),
-});
 
 /**
  * Define rules in a .rules.ts companion file.


### PR DESCRIPTION
## Summary
- Move all `dependencies` (`@commander-js/extra-typings`, `@modelcontextprotocol/sdk`, `inquirer`, `zod`) to `devDependencies` since the binary bundles everything
- Remove `zod` import from the public `./rules` export (`src/formats/rules.ts`) so consumers have zero transitive dependencies
- Relocate `RuleSetSchema` to `src/engine/loader.ts` where it's actually used internally

## Test plan
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun test` — 220 tests pass
- [x] `bun run build:check` — binary compiles successfully
- [ ] Verify `npm pack --dry-run` shows no bloat in published package

🤖 Generated with [Claude Code](https://claude.com/claude-code)