### PR TITLE
fix(ci): add auto-install to deploy-docs toolchain setup

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Setup toolchain
         uses: moonrepo/setup-toolchain@v0
+        with:
+          auto-install: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary
- The `deploy-docs.yml` workflow was missing `auto-install: true` on `moonrepo/setup-toolchain@v0`, causing `bun: command not found` during the docs build step
- Matches the pattern already used in `code-pull-request.yml`

## Test plan
- [ ] Merge and trigger `workflow_dispatch` to verify the deploy-docs workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)