### PR TITLE
feat(docs): add Cloudflare Web Analytics

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -23,6 +23,16 @@ export default defineConfig({
       editLink: {
         baseUrl: "https://github.com/archgate/cli/edit/main/docs/",
       },
+      head: [
+        {
+          tag: "script",
+          attrs: {
+            defer: true,
+            src: "https://static.cloudflareinsights.com/beacon.min.js",
+            "data-cf-beacon": '{"token": "cee359c05ecc496aabc4f40f05302a03"}',
+          },
+        },
+      ],
       sidebar: [
         {
           label: "Getting Started",


### PR DESCRIPTION
## Summary

- Add Cloudflare Web Analytics beacon to the documentation site via Starlight's `head` config

## Test plan

- [ ] Verify `docs/astro.config.mjs` includes the `head` entry with the correct Cloudflare token
- [ ] Build docs locally (`bun run docs:build`) and confirm the beacon script appears in the HTML `<head>`
- [ ] Deploy and verify analytics appear in the Cloudflare dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)