### PR TITLE
fix(ci): use workflow-scoped concurrency groups for PR pipelines

### DIFF
--- a/.github/workflows/code-pull-request.yml
+++ b/.github/workflows/code-pull-request.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: code-pr-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/update-lock.yaml
+++ b/.github/workflows/update-lock.yaml
@@ -7,7 +7,7 @@ on:
       - "package.json"
       - ".github/workflows/update-lock.yaml"
 concurrency:
-  group: pr-lock-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   update-lock:

--- a/.github/workflows/windows-smoke-test.yml
+++ b/.github/workflows/windows-smoke-test.yml
@@ -2,12 +2,12 @@ name: Windows Smoke Test
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, synchronize, reopened]
     branches:
       - main
 
 concurrency:
-  group: windows-smoke-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Replace hardcoded concurrency group prefixes (`code-pr-`, `windows-smoke-`, `pr-lock-`) with `${{ github.workflow }}-${{ ... }}` to auto-namespace by workflow name, preventing accidental group sharing if workflows are copied
- Remove unnecessary `edited` event type from `windows-smoke-test.yml` — it doesn't validate PR titles (only `code-pull-request.yml` does via commitlint), so re-running the Windows smoke test on title/body edits was wasteful

## Test plan
- [ ] Open a PR and verify both `Validate` and `Windows Smoke Test` run independently without cancelling each other
- [ ] Push a follow-up commit and verify only the previous run of each workflow is cancelled (not cross-workflow)
- [ ] Edit the PR title and verify only `Validate` re-runs (not `Windows Smoke Test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)