### PR TITLE
fix(ci): add explicit permissions to workflows

### DIFF
--- a/.github/workflows/code-pull-request.yml
+++ b/.github/workflows/code-pull-request.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/update-lock.yaml
+++ b/.github/workflows/update-lock.yaml
@@ -6,9 +6,13 @@ on:
     paths:
       - "package.json"
       - ".github/workflows/update-lock.yaml"
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
 jobs:
   update-lock:
     name: Update Package Lock

--- a/.github/workflows/windows-smoke-test.yml
+++ b/.github/workflows/windows-smoke-test.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Resolves all 3 open [code scanning alerts](https://github.com/archgate/cli/security/code-scanning) (`actions/missing-workflow-permissions`)
- Adds `permissions: contents: read` to `code-pull-request.yml`, `windows-smoke-test.yml`, and `update-lock.yaml`
- Follows the principle of least privilege — these workflows only need read access to checkout code (write operations in `update-lock.yaml` use a GitHub App token, not `GITHUB_TOKEN`)

## Test plan
- [ ] Validate workflow passes on this PR (self-testing — `code-pull-request.yml` is one of the changed files)
- [ ] Windows smoke test triggers and passes
- [ ] Verify code scanning alerts close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)