### PR TITLE
fix(ci): use npm trusted publishing (OIDC) instead of secret tokens

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build-and-publish:
@@ -82,6 +83,4 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish platform package
-        run: npm publish ./packages/${{ matrix.artifact }} --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish ./packages/${{ matrix.artifact }} --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,8 @@ jobs:
           workflow: release
           github-token: ${{ steps.generate_token.outputs.token }}
           branch: release
-          npm-token: ${{ secrets.NPM_TOKEN }}
+        env:
+          NPM_CONFIG_PROVENANCE: "true"
       - name: Save Bun Cache
         uses: actions/cache/save@v4
         if: steps.validate.outcome == 'success' && steps.restore-bun-cache.outputs.cache-hit != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ coverage
 # OS files
 .DS_Store
 
+# Local MCP config
+.mcp.json
+
 # Proto / Moon
 .moon/cache
 .moon/docker


### PR DESCRIPTION
## Summary
- Replace `NPM_TOKEN` secret-based auth with OIDC trusted publishing in both `release.yml` and `release-binaries.yml`
- Add `id-token: write` permission to `release-binaries.yml` for OIDC token exchange
- Add `--provenance` flag to platform package `npm publish` commands
- Replace `npm-token` input with `NPM_CONFIG_PROVENANCE` env var in `release.yml`
- Add `.mcp.json` to `.gitignore` to prevent local MCP config from being committed

## Before merging
Configure trusted publishers on [npmjs.com](https://npmjs.com) for all 4 packages:

| Package | Workflow to trust |
|---------|-------------------|
| `archgate` | `release.yml` |
| `archgate-darwin-arm64` | `release-binaries.yml` |
| `archgate-linux-x64` | `release-binaries.yml` |
| `archgate-win32-x64` | `release-binaries.yml` |

For each: **Settings → Publishing access → Add trusted publisher** with owner `archgate`, repo `cli`, and the workflow filename above.

After verifying the first successful publish, the `NPM_TOKEN` secret can be removed from the repository.

## Test plan
- [ ] Configure trusted publishers on npmjs.com for all 4 packages
- [ ] Merge and trigger a release to verify main package publishes via OIDC
- [ ] Trigger `release-binaries.yml` to verify platform packages publish via OIDC
- [ ] Verify provenance attestations appear on npmjs.com package pages
- [ ] Remove `NPM_TOKEN` secret after successful verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)