### PR TITLE
fix: replace Bun.$ shell calls with Bun.spawn for Windows compatibility

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,5 +1,5 @@
 import type { Command } from "@commander-js/extra-typings";
-import { $, semver } from "bun";
+import { semver } from "bun";
 import { logError } from "../helpers/log";
 
 const NPM_REGISTRY = "https://registry.npmjs.org/archgate/latest";
@@ -58,9 +58,13 @@ export function registerUpgradeCommand(program: Command) {
 
       console.log(`Upgrading ${currentVersion} -> ${latestVersion}...`);
 
-      const result = await $`npm install -g archgate@latest`.nothrow();
+      const proc = Bun.spawn(["npm", "install", "-g", "archgate@latest"], {
+        stdout: "inherit",
+        stderr: "inherit",
+      });
+      const exitCode = await proc.exited;
 
-      if (result.exitCode !== 0) {
+      if (exitCode !== 0) {
         logError(
           "Failed to install the latest version via npm.",
           "Try running `npm install -g archgate@latest` manually."

--- a/src/engine/git-files.ts
+++ b/src/engine/git-files.ts
@@ -1,15 +1,35 @@
 /** Git file-listing utilities for ADR scope resolution and change detection. */
 
+/**
+ * Run a git command using Bun.spawn (cross-platform, no shell).
+ * Bun.$ hangs on Windows due to pipe handling issues — this is the safe alternative.
+ */
+async function runGit(
+  args: string[],
+  cwd: string
+): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const text = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    throw new Error(`git ${args[0]} exited with code ${exitCode}`);
+  }
+  return text;
+}
+
 /** Get all git-tracked (non-ignored) files in the project. */
 export async function getGitTrackedFiles(
   projectRoot: string
 ): Promise<Set<string> | null> {
   try {
-    const result =
-      await Bun.$`git ls-files --cached --others --exclude-standard`
-        .cwd(projectRoot)
-        .quiet()
-        .text();
+    const result = await runGit(
+      ["ls-files", "--cached", "--others", "--exclude-standard"],
+      projectRoot
+    );
     return new Set(result.trim().split("\n").filter(Boolean));
   } catch {
     return null;
@@ -40,10 +60,10 @@ export async function resolveScopedFiles(
 /** Get changed files from git staging area. */
 export async function getStagedFiles(projectRoot: string): Promise<string[]> {
   try {
-    const result = await Bun.$`git diff --cached --name-only`
-      .cwd(projectRoot)
-      .quiet()
-      .text();
+    const result = await runGit(
+      ["diff", "--cached", "--name-only"],
+      projectRoot
+    );
     return result.trim().split("\n").filter(Boolean);
   } catch {
     return [];
@@ -53,14 +73,11 @@ export async function getStagedFiles(projectRoot: string): Promise<string[]> {
 /** Get all changed files (staged + unstaged). */
 export async function getChangedFiles(projectRoot: string): Promise<string[]> {
   try {
-    const staged = await Bun.$`git diff --cached --name-only`
-      .cwd(projectRoot)
-      .quiet()
-      .text();
-    const unstaged = await Bun.$`git diff --name-only`
-      .cwd(projectRoot)
-      .quiet()
-      .text();
+    const staged = await runGit(
+      ["diff", "--cached", "--name-only"],
+      projectRoot
+    );
+    const unstaged = await runGit(["diff", "--name-only"], projectRoot);
     const all = new Set([
       ...staged.trim().split("\n").filter(Boolean),
       ...unstaged.trim().split("\n").filter(Boolean),

--- a/src/engine/git-files.ts
+++ b/src/engine/git-files.ts
@@ -4,10 +4,7 @@
  * Run a git command using Bun.spawn (cross-platform, no shell).
  * Bun.$ hangs on Windows due to pipe handling issues — this is the safe alternative.
  */
-async function runGit(
-  args: string[],
-  cwd: string
-): Promise<string> {
+async function runGit(args: string[], cwd: string): Promise<string> {
   const proc = Bun.spawn(["git", ...args], {
     cwd,
     stdout: "pipe",

--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -21,12 +21,25 @@ export function installGit() {
  */
 export async function getChangedFiles(projectRoot: string): Promise<string[]> {
   try {
-    const result =
-      await $`git diff --name-only && git diff --cached --name-only`
-        .cwd(projectRoot)
-        .quiet()
-        .text();
-    const files = result.trim().split("\n").filter(Boolean);
+    const spawnOpts = {
+      cwd: projectRoot,
+      stdout: "pipe" as const,
+      stderr: "pipe" as const,
+    };
+    const unstaged = Bun.spawn(["git", "diff", "--name-only"], spawnOpts);
+    const staged = Bun.spawn(
+      ["git", "diff", "--cached", "--name-only"],
+      spawnOpts
+    );
+    const [unstagedText, stagedText] = await Promise.all([
+      new Response(unstaged.stdout).text(),
+      new Response(staged.stdout).text(),
+    ]);
+    await Promise.all([unstaged.exited, staged.exited]);
+    const files = [
+      ...unstagedText.trim().split("\n"),
+      ...stagedText.trim().split("\n"),
+    ].filter(Boolean);
     return [...new Set(files)];
   } catch {
     return [];

--- a/src/helpers/plugin-install.ts
+++ b/src/helpers/plugin-install.ts
@@ -7,11 +7,28 @@
 
 import { join } from "node:path";
 import { mkdirSync, unlinkSync } from "node:fs";
-import { $ } from "bun";
 import { logDebug } from "./log";
 import type { StoredCredentials } from "./auth";
 
 const PLUGINS_API = "https://plugins.archgate.dev";
+
+/**
+ * Run a command using Bun.spawn (cross-platform, no shell).
+ * Returns { exitCode, stdout }.
+ */
+async function run(
+  cmd: string[],
+  opts?: { cwd?: string }
+): Promise<{ exitCode: number; stdout: string }> {
+  const proc = Bun.spawn(cmd, {
+    cwd: opts?.cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+  return { exitCode, stdout };
+}
 
 // ---------------------------------------------------------------------------
 // Claude Code — CLI auto-install + manual fallback
@@ -28,8 +45,12 @@ export function buildMarketplaceUrl(credentials: StoredCredentials): string {
  * Check whether the `claude` CLI is available on the system PATH.
  */
 export async function isClaudeCliAvailable(): Promise<boolean> {
-  const result = await $`claude --version`.nothrow().quiet();
-  return result.exitCode === 0;
+  try {
+    const { exitCode } = await run(["claude", "--version"]);
+    return exitCode === 0;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -47,9 +68,7 @@ export async function installClaudePlugin(
   const url = buildMarketplaceUrl(credentials);
 
   logDebug("Adding archgate marketplace to claude CLI");
-  const addResult = await $`claude plugin marketplace add ${url}`
-    .nothrow()
-    .quiet();
+  const addResult = await run(["claude", "plugin", "marketplace", "add", url]);
   if (addResult.exitCode !== 0) {
     throw new Error(
       `claude plugin marketplace add failed (exit ${addResult.exitCode})`
@@ -57,9 +76,12 @@ export async function installClaudePlugin(
   }
 
   logDebug("Installing archgate plugin via claude CLI");
-  const installResult = await $`claude plugin install archgate@archgate`
-    .nothrow()
-    .quiet();
+  const installResult = await run([
+    "claude",
+    "plugin",
+    "install",
+    "archgate@archgate",
+  ]);
   if (installResult.exitCode !== 0) {
     throw new Error(
       `claude plugin install failed (exit ${installResult.exitCode})`
@@ -129,7 +151,7 @@ async function extractTarGz(
     mkdirSync(destDir, { recursive: true });
 
     // Extract using tar (available on macOS, Linux, and Windows 10+)
-    const result = await $`tar -xzf ${tmpArchive} -C ${destDir}`.nothrow();
+    const result = await run(["tar", "-xzf", tmpArchive, "-C", destDir]);
 
     if (result.exitCode !== 0) {
       throw new Error(
@@ -138,8 +160,8 @@ async function extractTarGz(
     }
 
     // List extracted files for reporting
-    const listResult = await $`tar -tzf ${tmpArchive}`.nothrow().text();
-    const files = listResult
+    const listResult = await run(["tar", "-tzf", tmpArchive]);
+    const files = listResult.stdout
       .split("\n")
       .map((f) => f.trim())
       .filter(Boolean);


### PR DESCRIPTION
## Summary

- **Replace all `Bun.$` template literal shell calls with `Bun.spawn()`** across 4 files
- `Bun.$` hangs indefinitely on Windows because the shell subprocess doesn't properly close stdin/stdout pipes, deadlocking the MCP server thread and freezing Claude Code / Cursor
- `Bun.spawn()` passes commands as arrays (no shell involved) and handles pipes correctly on all platforms

## Affected files

| File | Change |
|------|--------|
| `src/engine/git-files.ts` | Added `runGit()` helper; replaced 4 `Bun.$` git calls |
| `src/helpers/git.ts` | Replaced `$`git diff && git diff --cached`` (shell `&&`) with parallel `Bun.spawn` + `Promise.all` |
| `src/helpers/plugin-install.ts` | Added `run()` helper; replaced `claude` CLI and `tar` shell calls |
| `src/commands/upgrade.ts` | Replaced `$`npm install -g archgate@latest`` with `Bun.spawn` |

## Root cause

MCP tools `review_context` and `check` call git functions in `git-files.ts`. On Windows, `Bun.$` spawns a shell subprocess that never properly closes its pipes, causing the `await .text()` to hang forever. Since the MCP server runs in a single async thread, this blocks all further tool calls and freezes the host (Claude Code / Cursor).

`list_adrs` was unaffected because it only uses `readdirSync` and `Bun.file()` — no shell calls.

## What was left unchanged

- `helpers/git.ts` `installGit()` still uses `$` for `brew install git` and `apt-get install git` — these are **platform-guarded** (only run on macOS/Linux; Windows throws before reaching them)

## Test plan

- [ ] Verify `archgate check` works on Windows (was hanging before)
- [ ] Verify `review_context` MCP tool responds on Windows (was hanging before)
- [ ] Verify `list_adrs` still works (was unaffected, sanity check)
- [ ] Verify `archgate check` still works on macOS/Linux (regression check)
- [ ] Run `bun typecheck` — passes cleanly