### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+Only the latest release receives security updates. We recommend always running the most recent version.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, report them via [GitHub Security Advisories](https://github.com/archgate/cli/security/advisories/new).
+
+Include as much of the following as possible:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Affected versions
+- Any potential impact
+
+## Response Timeline
+
+- **Acknowledgment:** Within 3 business days of your report.
+- **Assessment:** We will evaluate severity and impact within 7 business days.
+- **Fix:** Critical vulnerabilities will be patched as soon as possible. A fix timeline will be communicated in the assessment response.
+
+## Disclosure Policy
+
+We follow coordinated disclosure. We ask that you give us reasonable time to address the issue before any public disclosure.


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` so GitHub surfaces the security policy tab on the repository
- Directs vulnerability reports to GitHub Security Advisories
- Documents response timelines (3-day ack, 7-day assessment) and coordinated disclosure policy

## Test plan
- [ ] Verify `SECURITY.md` renders correctly on the PR diff
- [ ] After merge, confirm the "Security" tab on GitHub shows the policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)