### PR TITLE
fix(ci): prevent expression injection in PR title handling

### DIFF
--- a/.github/workflows/code-pull-request.yml
+++ b/.github/workflows/code-pull-request.yml
@@ -41,7 +41,9 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Validate commit messages
         if: github.event_name == 'pull_request'
-        run: echo "${{ github.event.pull_request.title }}" | bun run commitlint
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | bun run commitlint
       - name: Validate
         id: validate
         run: bun run validate


### PR DESCRIPTION
## Summary
- Fixes Code scanning alert #4: Cache Poisoning via low-privileged code injection
- Passes `github.event.pull_request.title` through an `env:` block instead of direct `${{ }}` interpolation in a `run:` command, preventing shell command injection via crafted PR titles (CWE-094)

## Test plan
- [ ] Verify the `Validate commit messages` step still works correctly on this PR
- [ ] Confirm code scanning alert #4 is resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)