### PR TITLE
fix(ci): prevent release workflow self-cancellation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: release-${{ github.ref_name }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Change `cancel-in-progress` from `true` to `false` in the Release workflow concurrency group
- Prevents the `issue_comment`-triggered run from cancelling the `push`-triggered run mid-validation

## Test plan
- [ ] Merge a PR to main and verify both Release workflow runs complete without cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)