### PR TITLE
fix: pin platform package versions to exact release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,33 +83,6 @@ jobs:
           workflow: pull-request
           github-token: ${{ github.token }}
           branch: release
-      - name: Sync optional dependency versions on release branch
-        run: |
-          git fetch origin release || exit 0
-          git checkout release
-          VERSION=$(node -p "require('./package.json').version")
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            let changed = false;
-            for (const dep of Object.keys(pkg.optionalDependencies || {})) {
-              if (pkg.optionalDependencies[dep] !== pkg.version) {
-                pkg.optionalDependencies[dep] = pkg.version;
-                changed = true;
-              }
-            }
-            if (changed) {
-              fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-              process.stdout.write('updated');
-            } else {
-              process.stdout.write('unchanged');
-            }
-          "
-          if ! git diff --quiet package.json 2>/dev/null; then
-            git add package.json
-            git commit -m "chore: sync platform package versions to $VERSION"
-            git push origin release
-          fi
   validate-release-pr:
     name: Validate release PR
     needs: pull-request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,33 @@ jobs:
           workflow: pull-request
           github-token: ${{ github.token }}
           branch: release
+      - name: Sync optional dependency versions on release branch
+        run: |
+          git fetch origin release || exit 0
+          git checkout release
+          VERSION=$(node -p "require('./package.json').version")
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            let changed = false;
+            for (const dep of Object.keys(pkg.optionalDependencies || {})) {
+              if (pkg.optionalDependencies[dep] !== pkg.version) {
+                pkg.optionalDependencies[dep] = pkg.version;
+                changed = true;
+              }
+            }
+            if (changed) {
+              fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+              process.stdout.write('updated');
+            } else {
+              process.stdout.write('unchanged');
+            }
+          "
+          if ! git diff --quiet package.json 2>/dev/null; then
+            git add package.json
+            git commit -m "chore: sync platform package versions to $VERSION"
+            git push origin release
+          fi
   validate-release-pr:
     name: Validate release PR
     needs: pull-request

--- a/.simple-release.js
+++ b/.simple-release.js
@@ -1,3 +1,30 @@
+import { readFileSync, writeFileSync } from "node:fs";
 import { NpmProject } from "@simple-release/npm";
 
-export const project = new NpmProject();
+class ArchgateProject extends NpmProject {
+  async bump(options) {
+    const result = await super.bump(options);
+
+    if (result) {
+      const pkgPath = "package.json";
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+      const version = pkg.version;
+      let changed = false;
+
+      for (const dep of Object.keys(pkg.optionalDependencies || {})) {
+        if (pkg.optionalDependencies[dep] !== version) {
+          pkg.optionalDependencies[dep] = version;
+          changed = true;
+        }
+      }
+
+      if (changed) {
+        writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+      }
+    }
+
+    return result;
+  }
+}
+
+export const project = new ArchgateProject();

--- a/bun.lock
+++ b/bun.lock
@@ -19,9 +19,9 @@
         "zod": "4.3.6",
       },
       "optionalDependencies": {
-        "archgate-darwin-arm64": ">=0.1.1",
-        "archgate-linux-x64": ">=0.1.1",
-        "archgate-win32-x64": ">=0.1.1",
+        "archgate-darwin-arm64": "0.11.0",
+        "archgate-linux-x64": "0.11.0",
+        "archgate-win32-x64": "0.11.0",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -146,6 +146,12 @@
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
+
+    "archgate-darwin-arm64": ["archgate-darwin-arm64@0.11.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fKkDfgPfiucngfRbP1p1nfTT08aKHBVX4L9JqfFPotaYorS8uLUThcQY33pJ1mESgFAXcqC5rLCmIYxTgPl0gA=="],
+
+    "archgate-linux-x64": ["archgate-linux-x64@0.11.0", "", { "os": "linux", "cpu": "x64" }, "sha512-JRvbWC4LySfj5EhcQFA7LlhDOpsvv7qU3GOuxQURwOm8+brjmI9Rk0BRrhowKDZcqk2QswC6xkvwZTJ53eGdvQ=="],
+
+    "archgate-win32-x64": ["archgate-win32-x64@0.11.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dQ3t74V8BRJVFHERwymHKZBp/2FkxKgMxkhs/T/r+G5wmnbZmFml6ojX+LI47Ohp97NeTfgf1CRjeyrlQrSYFA=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
     "typescript": "^5"
   },
   "optionalDependencies": {
-    "archgate-darwin-arm64": ">=0.1.1",
-    "archgate-linux-x64": ">=0.1.1",
-    "archgate-win32-x64": ">=0.1.1"
+    "archgate-darwin-arm64": "0.11.0",
+    "archgate-linux-x64": "0.11.0",
+    "archgate-win32-x64": "0.11.0"
   }
 }


### PR DESCRIPTION
## Summary
- Pins `optionalDependencies` for platform binary packages to the exact current version (`0.11.0`) instead of `>=0.1.1`
- Adds a release workflow step that syncs optional dependency versions on the release branch when a new version is bumped

## Problem
Users running `archgate upgrade` were getting stale platform binaries because `>=0.1.1` allowed package managers to resolve any cached/older version. For example, a user on `archgate@0.11.0` could still have `archgate-win32-x64@0.10.0` because it satisfies `>=0.1.1`.

## Test plan
- [ ] Verify `bun run validate` passes
- [ ] Verify the release workflow sync step works by triggering a test release