### PR TITLE
feat: standalone installer and GitHub Releases distribution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,19 @@
   },
   "attribution": { "commit": "", "pr": "" },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>process.stdout.write(JSON.parse(d).tool_input.command))\"); if echo \"$CMD\" | grep -qE 'git\\s+commit'; then bun run validate > /dev/null 2>&1; EXIT=$?; if [ $EXIT -ne 0 ]; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"bun run validate failed (exit '\"$EXIT\"'). Fix issues before committing.\"}}'; fi; fi",
+            "timeout": 300,
+            "statusMessage": "Running validation before commit..."
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -10,7 +10,7 @@ on:
         required: true
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -80,3 +80,29 @@ jobs:
 
       - name: Publish platform package
         run: npm publish ./packages/${{ matrix.artifact }} --access public --provenance
+
+      - name: Prepare release asset (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cp dist/${{ matrix.artifact }} archgate
+          tar -czf ${{ matrix.artifact }}.tar.gz archgate
+          rm archgate
+
+      - name: Prepare release asset (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Copy-Item "dist/${{ matrix.artifact }}.exe" "archgate.exe"
+          Compress-Archive -Path "archgate.exe" -DestinationPath "${{ matrix.artifact }}.zip"
+          Remove-Item "archgate.exe"
+
+      - name: Upload release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            gh release upload "$TAG" "${{ matrix.artifact }}.zip" --clobber
+          else
+            gh release upload "$TAG" "${{ matrix.artifact }}.tar.gz" --clobber
+          fi

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ When a rule is violated, `archgate check` reports the file, line, and which ADR 
 
 ## Installation
 
+**Standalone** (no Node.js required):
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex
+```
+
+**Via npm** (or any Node.js package manager):
+
 ```bash
 # npm
 npm install -g archgate
@@ -64,8 +76,8 @@ npx archgate check         # run via package manager
 ## Quick start
 
 ```bash
-# 1. Install (pick your package manager)
-npm install -g archgate    # or: bun install -g archgate
+# 1. Install
+curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh  # or: npm install -g archgate
 
 # 2. Initialize governance in your project
 cd my-project

--- a/bun.lock
+++ b/bun.lock
@@ -19,9 +19,9 @@
         "zod": "4.3.6",
       },
       "optionalDependencies": {
-        "archgate-darwin-arm64": "0.11.1",
-        "archgate-linux-x64": "0.11.1",
-        "archgate-win32-x64": "0.11.1",
+        "archgate-darwin-arm64": "0.11.2",
+        "archgate-linux-x64": "0.11.2",
+        "archgate-win32-x64": "0.11.2",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -184,6 +184,10 @@
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
+
+    "archgate-darwin-arm64": ["archgate-darwin-arm64@0.11.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6zLgBves0TL4MbK7QgGUEw9yLVCTuDTVix3KiKpf8z2NQBK545+NIfp9WNgi66b3KAZRIyTbQYGglJ2D49uqrA=="],
+
+    "archgate-linux-x64": ["archgate-linux-x64@0.11.2", "", { "os": "linux", "cpu": "x64" }, "sha512-MjdvBaN5W5buokND94o3L+kzO4+djq3boMDxoo1sUzBF9jD+rAQ55A4nMU8TPItGvM5d3+mB5Etlw+jJxBzlfg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -14,7 +14,7 @@ Archgate lets teams write an ADR once and enforce it everywhere. ADRs are Markdo
 
 ## Installation
 
-Available via npm (`npm install -g archgate`), Homebrew, or standalone binary for macOS, Linux, and Windows.
+Install standalone (no Node.js required): `curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh` (macOS/Linux) or `irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex` (Windows PowerShell). Also available via npm (`npm install -g archgate`) or direct download from GitHub Releases.
 
 ## Documentation
 
@@ -115,9 +115,29 @@ Editor plugins are currently in beta. Sign up at [plugins.archgate.dev](https://
 
 Source: https://cli.archgate.dev/getting-started/installation/
 
-## Install globally
+## Install standalone (recommended)
 
-Install Archgate globally using your preferred package manager:
+The fastest way to install Archgate — no Node.js or package manager required:
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex
+```
+
+This downloads a pre-built binary for your platform and installs it to `~/.archgate/bin/`. The installer detects your shell profiles and offers to add the directory to your PATH.
+
+You can customize the install with environment variables:
+- `ARCHGATE_VERSION` — Install a specific version (e.g. `v0.11.2`). Default: latest release.
+- `ARCHGATE_INSTALL_DIR` — Custom install directory. Default: `~/.archgate/bin`.
+
+You can also download binaries directly from GitHub Releases: https://github.com/archgate/cli/releases
+
+## Install via npm
+
+Install Archgate globally using your preferred Node.js package manager:
 
 ```bash
 # npm
@@ -235,13 +255,17 @@ Source: https://cli.archgate.dev/getting-started/quick-start/
 
 ## 1. Install Archgate
 
-If you have not installed the CLI yet, install it globally via npm:
+If you have not installed the CLI yet:
 
 ```bash
+# Standalone (no Node.js required)
+curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+
+# Or via npm
 npm install -g archgate
 ```
 
-See the [Installation](/getting-started/installation/) page for platform details and troubleshooting.
+See the [Installation](/getting-started/installation/) page for all options, including Windows and custom install directories.
 
 ## 2. Initialize your project
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -14,7 +14,7 @@ Archgate lets teams write an ADR once and enforce it everywhere. ADRs are Markdo
 
 ## Installation
 
-Available via npm (`npm install -g archgate`), Homebrew, or standalone binary for macOS, Linux, and Windows.
+Install standalone (no Node.js required): `curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh` (macOS/Linux) or `irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex` (Windows PowerShell). Also available via npm (`npm install -g archgate`) or direct download from GitHub Releases.
 
 ## Documentation
 

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -1,11 +1,34 @@
 ---
 title: Installation
-description: Install the Archgate CLI on macOS, Linux, or Windows via npm, Homebrew, or standalone binary. Start enforcing ADRs as executable code rules in minutes.
+description: Install the Archgate CLI on macOS, Linux, or Windows via a one-line installer, npm, or standalone binary. Start enforcing ADRs as executable code rules in minutes.
 ---
 
-## Install globally
+## Install standalone (recommended)
 
-Install Archgate globally using your preferred package manager:
+The fastest way to install Archgate — no Node.js or package manager required:
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex
+```
+
+This downloads a pre-built binary for your platform and installs it to `~/.archgate/bin/`. The installer detects your shell profiles and offers to add the directory to your PATH.
+
+You can customize the install with environment variables:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `ARCHGATE_VERSION` | Install a specific version (e.g. `v0.11.2`) | Latest release |
+| `ARCHGATE_INSTALL_DIR` | Custom install directory | `~/.archgate/bin` |
+
+You can also download binaries directly from [GitHub Releases](https://github.com/archgate/cli/releases).
+
+## Install via npm
+
+Install Archgate globally using your preferred Node.js package manager:
 
 ```bash
 # npm

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -19,10 +19,10 @@ This downloads a pre-built binary for your platform and installs it to `~/.archg
 
 You can customize the install with environment variables:
 
-| Variable | Description | Default |
-| --- | --- | --- |
-| `ARCHGATE_VERSION` | Install a specific version (e.g. `v0.11.2`) | Latest release |
-| `ARCHGATE_INSTALL_DIR` | Custom install directory | `~/.archgate/bin` |
+| Variable               | Description                                 | Default           |
+| ---------------------- | ------------------------------------------- | ----------------- |
+| `ARCHGATE_VERSION`     | Install a specific version (e.g. `v0.11.2`) | Latest release    |
+| `ARCHGATE_INSTALL_DIR` | Custom install directory                    | `~/.archgate/bin` |
 
 You can also download binaries directly from [GitHub Releases](https://github.com/archgate/cli/releases).
 

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -5,13 +5,17 @@ description: Get started with Archgate in under 5 minutes. Initialize a project,
 
 ## 1. Install Archgate
 
-If you have not installed the CLI yet, install it globally via npm:
+If you have not installed the CLI yet:
 
 ```bash
+# Standalone (no Node.js required)
+curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+
+# Or via npm
 npm install -g archgate
 ```
 
-See the [Installation](/getting-started/installation/) page for platform details and troubleshooting.
+See the [Installation](/getting-started/installation/) page for all options, including Windows and custom install directories.
 
 ## 2. Initialize your project
 

--- a/docs/src/content/docs/guides/ci-integration.mdx
+++ b/docs/src/content/docs/guides/ci-integration.mdx
@@ -176,7 +176,7 @@ jobs:
 This works in any environment with `curl` and `tar` — no runtime dependencies needed. You can pin a version with the `ARCHGATE_VERSION` environment variable:
 
 ```yaml
-      - run: curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | ARCHGATE_VERSION=v0.11.2 sh
+- run: curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | ARCHGATE_VERSION=v0.11.2 sh
 ```
 
 ## Bun-based CI

--- a/docs/src/content/docs/guides/ci-integration.mdx
+++ b/docs/src/content/docs/guides/ci-integration.mdx
@@ -159,6 +159,26 @@ adr-compliance:
     - archgate check
 ```
 
+## Standalone installer (no Node.js)
+
+If your CI environment does not have Node.js, use the standalone installer to download a pre-built binary directly from GitHub Releases:
+
+```yaml
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+      - run: ~/.archgate/bin/archgate check --ci
+```
+
+This works in any environment with `curl` and `tar` — no runtime dependencies needed. You can pin a version with the `ARCHGATE_VERSION` environment variable:
+
+```yaml
+      - run: curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | ARCHGATE_VERSION=v0.11.2 sh
+```
+
 ## Bun-based CI
 
 If your CI already uses Bun, install Archgate with `bun` instead of `npm`:
@@ -178,7 +198,7 @@ jobs:
 
 Archgate works with any CI system that can run shell commands. The pattern is always the same:
 
-1. Install: `npm install -g archgate` (or `bun install -g archgate`)
+1. Install: `npm install -g archgate`, `bun install -g archgate`, or use the [standalone installer](/getting-started/installation/#install-standalone-recommended)
 2. Run: `archgate check`
 3. Check the exit code (0 = pass, 1 = violations, 2 = error)
 

--- a/docs/src/content/docs/pt-br/getting-started/installation.mdx
+++ b/docs/src/content/docs/pt-br/getting-started/installation.mdx
@@ -19,10 +19,10 @@ Isso baixa um binário pré-compilado para sua plataforma e instala em `~/.archg
 
 Você pode personalizar a instalação com variáveis de ambiente:
 
-| Variável | Descrição | Padrão |
-| --- | --- | --- |
-| `ARCHGATE_VERSION` | Instalar uma versão específica (ex: `v0.11.2`) | Última versão |
-| `ARCHGATE_INSTALL_DIR` | Diretório de instalação personalizado | `~/.archgate/bin` |
+| Variável               | Descrição                                      | Padrão            |
+| ---------------------- | ---------------------------------------------- | ----------------- |
+| `ARCHGATE_VERSION`     | Instalar uma versão específica (ex: `v0.11.2`) | Última versão     |
+| `ARCHGATE_INSTALL_DIR` | Diretório de instalação personalizado          | `~/.archgate/bin` |
 
 Você também pode baixar os binários diretamente das [GitHub Releases](https://github.com/archgate/cli/releases).
 

--- a/docs/src/content/docs/pt-br/getting-started/installation.mdx
+++ b/docs/src/content/docs/pt-br/getting-started/installation.mdx
@@ -1,11 +1,34 @@
 ---
 title: Instalação
-description: Instale o Archgate CLI no macOS, Linux ou Windows via npm, Homebrew ou binário standalone. Comece a aplicar ADRs como regras de código executáveis em minutos.
+description: Instale o Archgate CLI no macOS, Linux ou Windows via instalador, npm ou binário standalone. Comece a aplicar ADRs como regras de código executáveis em minutos.
 ---
 
-## Instalar globalmente
+## Instalação standalone (recomendado)
 
-Instale o Archgate globalmente usando seu gerenciador de pacotes preferido:
+A forma mais rápida de instalar o Archgate — sem necessidade de Node.js ou gerenciador de pacotes:
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex
+```
+
+Isso baixa um binário pré-compilado para sua plataforma e instala em `~/.archgate/bin/`. O instalador detecta os perfis do seu shell e oferece adicionar o diretório ao seu PATH.
+
+Você pode personalizar a instalação com variáveis de ambiente:
+
+| Variável | Descrição | Padrão |
+| --- | --- | --- |
+| `ARCHGATE_VERSION` | Instalar uma versão específica (ex: `v0.11.2`) | Última versão |
+| `ARCHGATE_INSTALL_DIR` | Diretório de instalação personalizado | `~/.archgate/bin` |
+
+Você também pode baixar os binários diretamente das [GitHub Releases](https://github.com/archgate/cli/releases).
+
+## Instalar via npm
+
+Instale o Archgate globalmente usando seu gerenciador de pacotes Node.js preferido:
 
 ```bash
 # npm

--- a/docs/src/content/docs/pt-br/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/pt-br/getting-started/quick-start.mdx
@@ -5,13 +5,17 @@ description: Comece a usar o Archgate em menos de 5 minutos. Inicialize um proje
 
 ## 1. Instalar o Archgate
 
-Se você ainda não instalou a CLI, instale-a globalmente via npm:
+Se você ainda não instalou a CLI:
 
 ```bash
+# Standalone (sem necessidade de Node.js)
+curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+
+# Ou via npm
 npm install -g archgate
 ```
 
-Veja a página de [Instalação](/pt-br/getting-started/installation/) para detalhes de plataforma e solução de problemas.
+Veja a página de [Instalação](/pt-br/getting-started/installation/) para todas as opções, incluindo Windows e diretórios de instalação personalizados.
 
 ## 2. Inicializar seu projeto
 

--- a/docs/src/content/docs/pt-br/guides/ci-integration.mdx
+++ b/docs/src/content/docs/pt-br/guides/ci-integration.mdx
@@ -176,7 +176,7 @@ jobs:
 Isso funciona em qualquer ambiente com `curl` e `tar` — sem dependências de runtime. Você pode fixar uma versão com a variável de ambiente `ARCHGATE_VERSION`:
 
 ```yaml
-      - run: curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | ARCHGATE_VERSION=v0.11.2 sh
+- run: curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | ARCHGATE_VERSION=v0.11.2 sh
 ```
 
 ## CI baseado em Bun

--- a/docs/src/content/docs/pt-br/guides/ci-integration.mdx
+++ b/docs/src/content/docs/pt-br/guides/ci-integration.mdx
@@ -159,6 +159,26 @@ adr-compliance:
     - archgate check
 ```
 
+## Instalador standalone (sem Node.js)
+
+Se seu ambiente de CI não possui Node.js, use o instalador standalone para baixar um binário pré-compilado diretamente das GitHub Releases:
+
+```yaml
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+      - run: ~/.archgate/bin/archgate check --ci
+```
+
+Isso funciona em qualquer ambiente com `curl` e `tar` — sem dependências de runtime. Você pode fixar uma versão com a variável de ambiente `ARCHGATE_VERSION`:
+
+```yaml
+      - run: curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | ARCHGATE_VERSION=v0.11.2 sh
+```
+
 ## CI baseado em Bun
 
 Se seu CI já usa Bun, instale o Archgate com `bun` ao invés de `npm`:
@@ -178,7 +198,7 @@ jobs:
 
 O Archgate funciona com qualquer sistema de CI que consiga executar comandos shell. O padrão é sempre o mesmo:
 
-1. Instalar: `npm install -g archgate` (ou `bun install -g archgate`)
+1. Instalar: `npm install -g archgate`, `bun install -g archgate`, ou use o [instalador standalone](/pt-br/getting-started/installation/#instalação-standalone-recomendado)
 2. Executar: `archgate check`
 3. Verificar o código de saída (0 = aprovado, 1 = violações, 2 = erro)
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,70 @@
+# Archgate installer for Windows
+# Usage: irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex
+$ErrorActionPreference = "Stop"
+
+$Repo = "archgate/cli"
+$Artifact = "archgate-win32-x64"
+$InstallDir = if ($env:ARCHGATE_INSTALL_DIR) { $env:ARCHGATE_INSTALL_DIR } else { "$HOME\.archgate\bin" }
+
+# --- Check architecture ---
+
+$Arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+if ($Arch -ne "X64") {
+    Write-Error "Error: unsupported architecture: $Arch. archgate supports x64 only on Windows."
+    exit 1
+}
+
+# --- Resolve version ---
+
+function Get-LatestVersion {
+    if ($env:ARCHGATE_VERSION) {
+        return $env:ARCHGATE_VERSION
+    }
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+    return $release.tag_name
+}
+
+$Version = Get-LatestVersion
+if (-not $Version) {
+    Write-Error "Error: could not determine latest version."
+    exit 1
+}
+
+# --- Download and install ---
+
+$Url = "https://github.com/$Repo/releases/download/$Version/$Artifact.zip"
+
+Write-Host "Installing archgate $Version ($Artifact)..."
+
+$TmpDir = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "archgate-install-$(Get-Random)")
+try {
+    $ZipPath = Join-Path $TmpDir "archgate.zip"
+    Invoke-WebRequest -Uri $Url -OutFile $ZipPath -UseBasicParsing
+
+    Expand-Archive -Path $ZipPath -DestinationPath $TmpDir -Force
+
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+
+    Move-Item -Path (Join-Path $TmpDir "archgate.exe") -Destination (Join-Path $InstallDir "archgate.exe") -Force
+} finally {
+    Remove-Item -Path $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "archgate $Version installed to $InstallDir\archgate.exe"
+
+# --- Update PATH guidance ---
+
+$CurrentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($CurrentPath -notlike "*$InstallDir*") {
+    Write-Host ""
+    Write-Host "To add archgate to your PATH, run:"
+    Write-Host ""
+    Write-Host "  [Environment]::SetEnvironmentVariable('Path', '$InstallDir;' + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')"
+    Write-Host ""
+    Write-Host "Then restart your terminal."
+}
+
+Write-Host ""
+Write-Host "Run 'archgate --help' to get started."

--- a/install.ps1
+++ b/install.ps1
@@ -54,16 +54,29 @@ try {
 
 Write-Host "archgate $Version installed to $InstallDir\archgate.exe"
 
-# --- Update PATH guidance ---
+# --- Update PATH ---
 
 $CurrentPath = [Environment]::GetEnvironmentVariable("Path", "User")
 if ($CurrentPath -notlike "*$InstallDir*") {
     Write-Host ""
-    Write-Host "To add archgate to your PATH, run:"
+    Write-Host "archgate is not on your PATH."
     Write-Host ""
-    Write-Host "  [Environment]::SetEnvironmentVariable('Path', '$InstallDir;' + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')"
+    Write-Host "  Will add: $InstallDir"
     Write-Host ""
-    Write-Host "Then restart your terminal."
+
+    $answer = Read-Host "Add to your user PATH now? [Y/n]"
+    if ($answer -match '^[nN]') {
+        Write-Host ""
+        Write-Host "Skipped. To add manually, run:"
+        Write-Host ""
+        Write-Host "  [Environment]::SetEnvironmentVariable('Path', '$InstallDir;' + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')"
+    } else {
+        [Environment]::SetEnvironmentVariable("Path", "$InstallDir;$CurrentPath", "User")
+        $env:Path = "$InstallDir;$env:Path"
+        Write-Host "  Updated user PATH."
+    }
+    Write-Host ""
+    Write-Host "Restart your terminal for the change to take effect in new sessions."
 }
 
 Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,248 @@
+#!/bin/sh
+# Archgate installer for macOS and Linux
+# Usage: curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+set -eu
+
+REPO="archgate/cli"
+INSTALL_DIR="${ARCHGATE_INSTALL_DIR:-$HOME/.archgate/bin}"
+
+# --- Detect platform ---
+
+detect_platform() {
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os" in
+    Darwin) platform="darwin" ;;
+    Linux)  platform="linux" ;;
+    *)
+      echo "Error: unsupported OS: $os" >&2
+      echo "archgate supports macOS (ARM64) and Linux (x86_64)." >&2
+      exit 1
+      ;;
+  esac
+
+  case "$arch" in
+    arm64|aarch64) arch="arm64" ;;
+    x86_64|amd64)  arch="x64" ;;
+    *)
+      echo "Error: unsupported architecture: $arch" >&2
+      echo "archgate supports arm64 (macOS) and x64 (Linux)." >&2
+      exit 1
+      ;;
+  esac
+
+  # Validate supported combinations
+  if [ "$platform" = "darwin" ] && [ "$arch" != "arm64" ]; then
+    echo "Error: macOS is only supported on ARM64 (Apple Silicon)." >&2
+    exit 1
+  fi
+  if [ "$platform" = "linux" ] && [ "$arch" != "x64" ]; then
+    echo "Error: Linux is only supported on x86_64." >&2
+    exit 1
+  fi
+
+  ARTIFACT="archgate-${platform}-${arch}"
+}
+
+# --- Resolve version ---
+
+resolve_version() {
+  if [ -n "${ARCHGATE_VERSION:-}" ]; then
+    VERSION="$ARCHGATE_VERSION"
+    return
+  fi
+
+  if command -v curl >/dev/null 2>&1; then
+    VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed 's/.*"tag_name": *"//;s/".*//')"
+  elif command -v wget >/dev/null 2>&1; then
+    VERSION="$(wget -qO- "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed 's/.*"tag_name": *"//;s/".*//')"
+  else
+    echo "Error: curl or wget is required." >&2
+    exit 1
+  fi
+
+  if [ -z "$VERSION" ]; then
+    echo "Error: could not determine latest version." >&2
+    exit 1
+  fi
+}
+
+# --- Download and install ---
+
+download_and_install() {
+  url="https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT}.tar.gz"
+
+  echo "Installing archgate ${VERSION} (${ARTIFACT})..."
+
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$tmpdir/archgate.tar.gz"
+  else
+    wget -qO "$tmpdir/archgate.tar.gz" "$url"
+  fi
+
+  tar -xzf "$tmpdir/archgate.tar.gz" -C "$tmpdir"
+  mkdir -p "$INSTALL_DIR"
+  mv "$tmpdir/archgate" "$INSTALL_DIR/archgate"
+  chmod +x "$INSTALL_DIR/archgate"
+}
+
+# --- Update PATH ---
+
+get_shell_profiles() {
+  profiles=""
+
+  # Zsh
+  for f in "$HOME/.zshrc" "$HOME/.zshenv" "$HOME/.zprofile"; do
+    if [ -f "$f" ]; then
+      profiles="$profiles $f"
+      break
+    fi
+  done
+
+  # Bash — login vs interactive, Linux vs macOS
+  for f in "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
+    if [ -f "$f" ]; then
+      profiles="$profiles $f"
+      break
+    fi
+  done
+
+  # Fish
+  fish_config="$HOME/.config/fish/config.fish"
+  if [ -f "$fish_config" ]; then
+    profiles="$profiles $fish_config"
+  fi
+
+  # Nushell
+  for f in "$HOME/.config/nushell/env.nu" "$HOME/Library/Application Support/nushell/env.nu"; do
+    if [ -f "$f" ]; then
+      profiles="$profiles $f"
+      break
+    fi
+  done
+
+  # Ion
+  if [ -f "$HOME/.config/ion/initrc" ]; then
+    profiles="$profiles $HOME/.config/ion/initrc"
+  fi
+
+  # Csh / Tcsh
+  for f in "$HOME/.cshrc" "$HOME/.tcshrc"; do
+    if [ -f "$f" ]; then
+      profiles="$profiles $f"
+      break
+    fi
+  done
+
+  echo "$profiles"
+}
+
+path_line_for() {
+  file="$1"
+  case "$file" in
+    *.fish)
+      echo "fish_add_path ${INSTALL_DIR}" ;;
+    *env.nu)
+      echo "\$env.PATH = (\$env.PATH | prepend '${INSTALL_DIR}')" ;;
+    *initrc)
+      echo "let path = [ ${INSTALL_DIR} \$path ]" ;;
+    *.cshrc|*.tcshrc)
+      echo "set path = ( ${INSTALL_DIR} \$path )" ;;
+    *)
+      echo "export PATH=\"${INSTALL_DIR}:\$PATH\"" ;;
+  esac
+}
+
+already_configured() {
+  file="$1"
+  grep -qF "${INSTALL_DIR}" "$file" 2>/dev/null
+}
+
+setup_path() {
+  # Already on PATH — nothing to do
+  case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*) return ;;
+  esac
+
+  profiles="$(get_shell_profiles)"
+
+  if [ -z "$profiles" ]; then
+    echo ""
+    echo "Could not detect any shell profile files."
+    echo "Manually add ${INSTALL_DIR} to your PATH."
+    return
+  fi
+
+  # Collect profiles that still need the PATH line
+  needs_update=""
+  already_done=""
+  for f in $profiles; do
+    if already_configured "$f"; then
+      already_done="$already_done $f"
+    else
+      needs_update="$needs_update $f"
+    fi
+  done
+
+  if [ -n "$already_done" ]; then
+    for f in $already_done; do
+      echo "  Already configured: $f"
+    done
+  fi
+
+  if [ -z "$needs_update" ]; then
+    echo "PATH is already configured in all detected shell profiles."
+    return
+  fi
+
+  echo ""
+  echo "Detected shell profiles to update:"
+  for f in $needs_update; do
+    echo "  $f  ->  $(path_line_for "$f")"
+  done
+  echo ""
+
+  # Prompt requires /dev/tty — available even when stdin is piped (curl | sh)
+  if [ ! -e /dev/tty ]; then
+    echo "No TTY available. To add archgate to your PATH manually, add the lines above to your shell profile."
+    return
+  fi
+
+  printf "Update these files now? [Y/n] "
+  read -r answer </dev/tty
+  case "$answer" in
+    [nN]*)
+      echo ""
+      echo "Skipped. To add archgate to your PATH manually, add the lines above to your shell profile."
+      return
+      ;;
+  esac
+
+  for f in $needs_update; do
+    line="$(path_line_for "$f")"
+    printf '\n# archgate\n%s\n' "$line" >> "$f"
+    echo "  Updated: $f"
+  done
+  echo ""
+  echo "Restart your shell or open a new terminal to use archgate."
+}
+
+# --- Main ---
+
+main() {
+  detect_platform
+  resolve_version
+  download_and_install
+
+  echo "archgate ${VERSION} installed to ${INSTALL_DIR}/archgate"
+  setup_path
+
+  echo ""
+  echo "Run 'archgate --help' to get started."
+}
+
+main


### PR DESCRIPTION
## Summary

- **Standalone installers**: `install.sh` (macOS/Linux) and `install.ps1` (Windows) download pre-built binaries from GitHub Releases — no Node.js or npm required
- **GitHub Releases assets**: The release workflow now uploads `.tar.gz` (Unix) and `.zip` (Windows) archives alongside the existing npm publish
- **Documentation updated**: All installation docs (EN + pt-BR), README, CI integration guides, and LLM docs now feature the standalone installer as the recommended method

This unblocks developers outside the JavaScript ecosystem (.NET, Python, Go, etc.) from using archgate without installing Node.js.

### Shell installer features
- Detects platform (macOS/Linux) and architecture (arm64/x64)
- Detects all installed shell profiles (zsh, bash, fish, nushell, ion, csh/tcsh) and generates correct PATH syntax for each
- Prompts for confirmation before modifying any profile files (reads from `/dev/tty` so it works even when piped via `curl | sh`)
- Supports `ARCHGATE_VERSION` and `ARCHGATE_INSTALL_DIR` env vars for customization

## Test plan

- [ ] Verify `release-binaries.yml` syntax is valid (GitHub Actions linter)
- [ ] Run `bash -n install.sh` to validate shell script syntax
- [ ] Test `install.sh` on macOS and Linux (manual or CI)
- [ ] Test `install.ps1` on Windows (manual)
- [ ] Verify docs render correctly on the Astro site
- [ ] Trigger a test release to confirm binaries appear as GitHub Release assets