### PR TITLE
fix: update lockfile and detect TLS errors in login

### DIFF
--- a/.simple-release.js
+++ b/.simple-release.js
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 
 import { NpmProject } from "@simple-release/npm";
@@ -21,6 +22,7 @@ class ArchgateProject extends NpmProject {
 
       if (changed) {
         writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+        execSync("bun install", { stdio: "inherit" });
       }
     }
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,9 +19,9 @@
         "zod": "4.3.6",
       },
       "optionalDependencies": {
-        "archgate-darwin-arm64": "0.11.2",
-        "archgate-linux-x64": "0.11.2",
-        "archgate-win32-x64": "0.11.2",
+        "archgate-darwin-arm64": "0.12.0",
+        "archgate-linux-x64": "0.12.0",
+        "archgate-win32-x64": "0.12.0",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -184,10 +184,6 @@
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
-
-    "archgate-darwin-arm64": ["archgate-darwin-arm64@0.11.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6zLgBves0TL4MbK7QgGUEw9yLVCTuDTVix3KiKpf8z2NQBK545+NIfp9WNgi66b3KAZRIyTbQYGglJ2D49uqrA=="],
-
-    "archgate-linux-x64": ["archgate-linux-x64@0.11.2", "", { "os": "linux", "cpu": "x64" }, "sha512-MjdvBaN5W5buokND94o3L+kzO4+djq3boMDxoo1sUzBF9jD+rAQ55A4nMU8TPItGvM5d3+mB5Etlw+jJxBzlfg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -12,6 +12,7 @@ import {
   clearCredentials,
 } from "../helpers/auth";
 import { logError, logInfo } from "../helpers/log";
+import { isTlsError, tlsHintMessage } from "../helpers/tls";
 
 export function registerLoginCommand(program: Command) {
   const login = program
@@ -32,6 +33,10 @@ export function registerLoginCommand(program: Command) {
 
       await runDeviceFlow();
     } catch (err) {
+      if (isTlsError(err)) {
+        logError(tlsHintMessage());
+        process.exit(1);
+      }
       logError(err instanceof Error ? err.message : String(err));
       process.exit(1);
     }
@@ -67,6 +72,10 @@ export function registerLoginCommand(program: Command) {
         await clearCredentials();
         await runDeviceFlow();
       } catch (err) {
+        if (isTlsError(err)) {
+          logError(tlsHintMessage());
+          process.exit(1);
+        }
         logError(err instanceof Error ? err.message : String(err));
         process.exit(1);
       }

--- a/src/helpers/tls.ts
+++ b/src/helpers/tls.ts
@@ -1,0 +1,40 @@
+/**
+ * tls.ts — Detect TLS/SSL interception errors common in corporate environments
+ * and provide actionable guidance to the user.
+ */
+
+const TLS_ERROR_PATTERNS = [
+  "self signed certificate",
+  "unable to get local issuer certificate",
+  "certificate has expired",
+  "unable to verify the first certificate",
+  "CERT_HAS_EXPIRED",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+];
+
+/**
+ * Returns true when the error looks like a TLS certificate verification
+ * failure — typically caused by a corporate proxy performing SSL inspection.
+ */
+export function isTlsError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return TLS_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+}
+
+/**
+ * Human-readable hint explaining the TLS failure and how to fix it.
+ */
+export function tlsHintMessage(): string {
+  return [
+    "TLS certificate verification failed.",
+    "This typically happens behind a corporate proxy that performs SSL inspection.",
+    "",
+    "To fix this, set the NODE_EXTRA_CA_CERTS environment variable to your corporate CA certificate:",
+    "",
+    '  export NODE_EXTRA_CA_CERTS="/path/to/corporate-ca.pem"',
+    "",
+    "Then retry the command.",
+  ].join("\n");
+}

--- a/tests/helpers/tls.test.ts
+++ b/tests/helpers/tls.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { isTlsError, tlsHintMessage } from "../../src/helpers/tls";
+
+describe("isTlsError", () => {
+  test("detects 'self signed certificate in certificate chain'", () => {
+    const err = new Error("self signed certificate in certificate chain");
+    expect(isTlsError(err)).toBe(true);
+  });
+
+  test("detects 'self signed certificate' (without chain suffix)", () => {
+    expect(isTlsError(new Error("self signed certificate"))).toBe(true);
+  });
+
+  test("detects SELF_SIGNED_CERT_IN_CHAIN code", () => {
+    expect(isTlsError(new Error("SELF_SIGNED_CERT_IN_CHAIN"))).toBe(true);
+  });
+
+  test("detects 'unable to verify the first certificate'", () => {
+    expect(
+      isTlsError(new Error("unable to verify the first certificate"))
+    ).toBe(true);
+  });
+
+  test("detects UNABLE_TO_GET_ISSUER_CERT_LOCALLY code", () => {
+    expect(isTlsError(new Error("UNABLE_TO_GET_ISSUER_CERT_LOCALLY"))).toBe(
+      true
+    );
+  });
+
+  test("returns false for unrelated errors", () => {
+    expect(isTlsError(new Error("fetch failed"))).toBe(false);
+    expect(isTlsError(new Error("ECONNREFUSED"))).toBe(false);
+  });
+
+  test("handles non-Error values", () => {
+    expect(isTlsError("self signed certificate")).toBe(true);
+    expect(isTlsError(42)).toBe(false);
+  });
+});
+
+describe("tlsHintMessage", () => {
+  test("mentions NODE_EXTRA_CA_CERTS", () => {
+    expect(tlsHintMessage()).toContain("NODE_EXTRA_CA_CERTS");
+  });
+
+  test("mentions corporate proxy", () => {
+    expect(tlsHintMessage()).toContain("corporate proxy");
+  });
+});


### PR DESCRIPTION
## Summary
- **Lockfile fix**: The 0.12.0 release PR bumped platform package versions in `package.json` but did not regenerate `bun.lock`, causing `bun install --frozen-lockfile` to fail in CI.
- **TLS error handling**: Corporate proxies performing SSL inspection cause `fetch()` to fail with opaque certificate errors (e.g. `self signed certificate in certificate chain`). The login command now detects these and shows an actionable message telling the user to set `NODE_EXTRA_CA_CERTS`.

## Test plan
- [x] `bun run validate` passes
- [x] New tests in `tests/helpers/tls.test.ts` (9 tests) cover pattern detection and edge cases
- [x] CI should pass with the updated lockfile