### PR TITLE
fix: split upload release asset step for Windows compatibility

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -96,13 +96,19 @@ jobs:
           Compress-Archive -Path "archgate.exe" -DestinationPath "${{ matrix.artifact }}.zip"
           Remove-Item "archgate.exe"
 
-      - name: Upload release asset
+      - name: Upload release asset (Unix)
+        if: runner.os != 'Windows'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ github.event.release.tag_name || inputs.tag }}"
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            gh release upload "$TAG" "${{ matrix.artifact }}.zip" --clobber
-          else
-            gh release upload "$TAG" "${{ matrix.artifact }}.tar.gz" --clobber
-          fi
+          gh release upload "$TAG" "${{ matrix.artifact }}.tar.gz" --clobber
+
+      - name: Upload release asset (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $tag = "${{ github.event.release.tag_name || inputs.tag }}"
+          gh release upload $tag "${{ matrix.artifact }}.zip" --clobber


### PR DESCRIPTION
## Summary
- The "Upload release asset" step in `release-binaries.yml` used bash `if/then` syntax without specifying `shell: bash`, so on Windows runners it defaulted to PowerShell and failed with `Missing '(' after 'if' in if statement`
- Split the single step into platform-specific "Upload release asset (Unix)" and "Upload release asset (Windows)" steps, matching the existing pattern used by other steps in the workflow

## Test plan
- [ ] Re-run the failed workflow on a new release or via `workflow_dispatch` to confirm the Windows job succeeds

Fixes: https://github.com/archgate/cli/actions/runs/23262688091/job/67635158745