### PR TITLE
fix: use PROCESSOR_ARCHITECTURE for Windows arch detection in installer

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -8,8 +8,8 @@ $InstallDir = if ($env:ARCHGATE_INSTALL_DIR) { $env:ARCHGATE_INSTALL_DIR } else 
 
 # --- Check architecture ---
 
-$Arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-if ($Arch -ne "X64") {
+$Arch = $env:PROCESSOR_ARCHITECTURE
+if ($Arch -ne "AMD64") {
     Write-Error "Error: unsupported architecture: $Arch. archgate supports x64 only on Windows."
     exit 1
 }


### PR DESCRIPTION
## Summary
- Fixes Windows installer failing with `unsupported architecture: .` when run via `irm | iex`
- Replaces `[System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture` (a .NET enum that can stringify as empty in piped execution) with `$env:PROCESSOR_ARCHITECTURE` (a reliable Windows env var returning `"AMD64"` for x64)

## Test plan
- [ ] Run `irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex` on a Windows x64 machine
- [ ] Verify the architecture check passes and installation proceeds