### PR TITLE
fix: address valid AI code quality findings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ resolve_version() {
       ;;
     *)
       echo "Error: unexpected response from GitHub releases API." >&2
-      echo "Response (truncated): $(printf '%s' "$response" | head -c 200)" >&2
+      echo "Response (truncated): $(printf '%s' "$response" | cut -c1-200)" >&2
       exit 1
       ;;
   esac

--- a/tests/commands/plugin/index.test.ts
+++ b/tests/commands/plugin/index.test.ts
@@ -4,32 +4,31 @@ import { Command } from "@commander-js/extra-typings";
 
 import { registerPluginCommand } from "../../../src/commands/plugin/index";
 
+const createProgramAndPlugin = () => {
+  const program = new Command();
+  registerPluginCommand(program);
+  const plugin = program.commands.find((c) => c.name() === "plugin")!;
+  return { program, plugin };
+};
+
 describe("registerPluginCommand", () => {
   test("registers 'plugin' as a subcommand", () => {
-    const program = new Command();
-    registerPluginCommand(program);
-    const sub = program.commands.find((c) => c.name() === "plugin");
-    expect(sub).toBeDefined();
+    const { plugin } = createProgramAndPlugin();
+    expect(plugin).toBeDefined();
   });
 
   test("has a description", () => {
-    const program = new Command();
-    registerPluginCommand(program);
-    const sub = program.commands.find((c) => c.name() === "plugin")!;
-    expect(sub.description()).toBeTruthy();
+    const { plugin } = createProgramAndPlugin();
+    expect(plugin.description()).toBeTruthy();
   });
 
   test("registers 'url' subcommand", () => {
-    const program = new Command();
-    registerPluginCommand(program);
-    const plugin = program.commands.find((c) => c.name() === "plugin")!;
+    const { plugin } = createProgramAndPlugin();
     expect(plugin.commands.find((c) => c.name() === "url")).toBeDefined();
   });
 
   test("registers 'install' subcommand", () => {
-    const program = new Command();
-    registerPluginCommand(program);
-    const plugin = program.commands.find((c) => c.name() === "plugin")!;
+    const { plugin } = createProgramAndPlugin();
     expect(plugin.commands.find((c) => c.name() === "install")).toBeDefined();
   });
 });

--- a/tests/helpers/binary-upgrade.test.ts
+++ b/tests/helpers/binary-upgrade.test.ts
@@ -29,9 +29,9 @@ describe("getArtifactInfo", () => {
   test("returns .tar.gz extension for non-win32", () => {
     const info = getArtifactInfo();
     if (process.platform === "win32") return;
-    if (info === null) return;
-    expect(info.ext).toBe(".tar.gz");
-    expect(info.binaryName).toBe("archgate");
+    expect(info).not.toBeNull();
+    expect(info!.ext).toBe(".tar.gz");
+    expect(info!.binaryName).toBe("archgate");
   });
 });
 


### PR DESCRIPTION
## Summary

Reviewed the 7 AI findings from [GitHub Code Quality](https://github.com/archgate/cli/security/quality/ai-findings) and fixed the 3 that are genuinely valid:

- **install.sh:73** — Replace `head -c 200` with `cut -c1-200` for POSIX compliance (BSD/macOS `head` doesn't support `-c`)
- **tests/commands/plugin/index.test.ts** — Extract duplicated test setup (Command + registerPluginCommand + find) into a `createProgramAndPlugin()` helper
- **tests/helpers/binary-upgrade.test.ts:32** — Replace silent `if (info === null) return` with `expect(info).not.toBeNull()` so unsupported platforms fail explicitly instead of passing silently

### Findings deemed not valid (no fix needed)

| Finding | File | Reason |
|---------|------|--------|
| `toBeTruthy()` too weak | plugin/index.test.ts | Checking description exists is sufficient; hardcoding `toContain("plugin")` is brittle |
| Non-null `!` assertion | plugin/index.test.ts | Over-engineering for tests; if `find()` returns undefined the next assertion fails clearly |
| Mock `process.platform` | binary-upgrade.test.ts | `Object.defineProperty` on `process.platform` is fragile in Bun; platform-skip pattern is standard and CI runs across platforms |
| `i <= retries` off-by-one | test-utils.ts | Intentional: 1 initial try + N retries = N+1 total attempts; the `i === retries` guard on line 42 confirms this design |

## Test plan

- [x] `bun run validate` passes (lint, typecheck, format, 314 tests, ADR check, build)