### PR TITLE
docs: replace hardcoded content with source references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,29 +31,7 @@ bun run commit                # conventional commit wizard
 
 ### Commands
 
-Entry point: `src/cli.ts` (shebang `#!/usr/bin/env bun`). Commands registered via `register*Command(program)`.
-
-| Command                       | File                                      | Description                                                     |
-| ----------------------------- | ----------------------------------------- | --------------------------------------------------------------- |
-| `init`                        | `commands/init.ts`                        | Initialize Archgate governance in the current project           |
-| `check`                       | `commands/check.ts`                       | Run ADR compliance checks                                       |
-| `adr create`                  | `commands/adr/create.ts`                  | Create a new ADR                                                |
-| `adr list`                    | `commands/adr/list.ts`                    | List all ADRs (`--json`, `--domain`)                            |
-| `adr show <id>`               | `commands/adr/show.ts`                    | Show a specific ADR by ID                                       |
-| `adr update`                  | `commands/adr/update.ts`                  | Update an existing ADR by ID                                    |
-| `login`                       | `commands/login.ts`                       | Authenticate with GitHub to access archgate plugins             |
-| `login status`                | `commands/login.ts`                       | Show current authentication status                              |
-| `login logout`                | `commands/login.ts`                       | Remove stored credentials                                       |
-| `login refresh`               | `commands/login.ts`                       | Re-authenticate and claim a new token                           |
-| `review-context`              | `commands/review-context.ts`              | Pre-compute review context with ADR briefings for changed files |
-| `session-context`             | `commands/session-context/index.ts`       | Read AI editor session transcripts                              |
-| `session-context claude-code` | `commands/session-context/claude-code.ts` | Read Claude Code session transcript for the project             |
-| `session-context cursor`      | `commands/session-context/cursor.ts`      | Read Cursor agent session transcript for the project            |
-| `plugin`                      | `commands/plugin/index.ts`                | Manage archgate editor plugins                                  |
-| `plugin install`              | `commands/plugin/install.ts`              | Install the archgate plugin for the specified editor            |
-| `plugin url`                  | `commands/plugin/url.ts`                  | Print the authenticated plugin repository URL                   |
-| `upgrade`                     | `commands/upgrade.ts`                     | Upgrade Archgate to the latest version                          |
-| `clean`                       | `commands/clean.ts`                       | Clean the CLI temp files                                        |
+Entry point: `src/cli.ts` (shebang `#!/usr/bin/env bun`). Commands registered via `register*Command(program)`. See `src/commands/` for all command implementations — each file exports a `register*Command(program)` function.
 
 ### Key Paths
 
@@ -75,24 +53,13 @@ Zod schemas are the single source of truth. Types derived via `z.infer<>` — ne
 - Exit codes: 0 = success, 1 = violation, 2 = internal error
 - Deps: minimal; prefer Bun built-ins (see ARCH-006)
 
-## Toolchain (`.prototools`)
+## Toolchain
 
-Bun 1.3.9, Node LTS, npm 11.11.0. Minimum user-facing Bun: `>=1.2.21` (enforced in `src/cli.ts`).
+See `.prototools` for pinned tool versions. Minimum user-facing Bun version is enforced in `src/cli.ts`.
 
-## Self-Governance ADRs (`.archgate/adrs/`)
+## Self-Governance ADRs
 
-- `ARCH-001` — Command structure (register pattern, no business logic)
-- `ARCH-002` — Error handling (exit codes, log helpers)
-- `ARCH-003` — Output formatting (styleText, --json, no emoji)
-- `ARCH-004` — No barrel files (direct imports only)
-- `ARCH-005` — Testing standards (Bun test, fixtures, 80% coverage)
-- `ARCH-006` — Dependency policy (minimal deps, Bun built-ins)
-- `ARCH-007` — Cross-platform subprocess execution (Bun.spawn, no Bun.$)
-- `ARCH-008` — Typed command options (use addOption for choices/argParser)
-- `ARCH-009` — Centralized platform detection (use helpers/platform)
-- `ARCH-010` — Prefer Bun built-in JSON parsing (Bun.file().json())
-- `GEN-001` — Documentation site (Astro Starlight)
-- `GEN-002` — Documentation internationalization (en + pt-br parity)
+The CLI dogfoods itself — see `.archgate/adrs/` for the full list of ADRs and their companion `.rules.ts` files. Read them before making architectural changes.
 
 ## ADR Format
 

--- a/README.md
+++ b/README.md
@@ -95,29 +95,7 @@ archgate check
 
 ## Writing rules
 
-Each ADR can have a companion `.rules.ts` file that exports a plain object typed with `satisfies RuleSet`. Rules receive the list of files to check and return an array of violations with file paths and line numbers.
-
-See the [writing rules guide](https://cli.archgate.dev/guides/writing-rules/) for examples and the full [rule API reference](https://cli.archgate.dev/reference/rule-api/).
-
-## Commands
-
-| Command                  | Description                                                |
-| ------------------------ | ---------------------------------------------------------- |
-| `archgate init`          | Initialize `.archgate/` with example ADR and editor config |
-| `archgate check`         | Run ADR compliance checks (`--staged` for pre-commit)      |
-| `archgate adr create`    | Create a new ADR interactively                             |
-| `archgate adr list`      | List all ADRs (`--json`, `--domain`)                       |
-| `archgate adr show <id>` | Print a specific ADR                                       |
-| `archgate adr update`    | Update an ADR's frontmatter                                |
-| `archgate login`         | Authenticate with GitHub for editor plugins                |
-| `archgate upgrade`       | Upgrade to the latest release                              |
-| `archgate clean`         | Remove the CLI cache (`~/.archgate/`)                      |
-
-See the [CLI reference](https://cli.archgate.dev/reference/cli-commands/) for full usage and options.
-
-## CI and pre-commit hooks
-
-Add `archgate check` to your CI pipeline or pre-commit hooks to block merges that violate ADRs. See the [CI integration guide](https://cli.archgate.dev/guides/ci-integration/) and [pre-commit hooks guide](https://cli.archgate.dev/guides/pre-commit-hooks/) for setup instructions.
+Each ADR can have a companion `.rules.ts` file that exports automated checks. See the [writing rules guide](https://cli.archgate.dev/guides/writing-rules/) for examples and the full [rule API reference](https://cli.archgate.dev/reference/rule-api/).
 
 ## Supercharge with AI plugins
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -87,8 +87,9 @@ When you run `archgate check`, the CLI loads every ADR that has `rules: true` in
   
   
     Archgate governs its own development. The same tool that checks your code
-    checks ours. Six ADRs enforce command structure, error handling, output
-    formatting, testing, and more.
+    checks ours. Our own ADRs enforce command structure, error handling, output
+    formatting, testing, and more — [see them on
+    GitHub](https://github.com/archgate/cli/tree/main/.archgate/adrs).
   
 
 ## Editor plugins

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -53,8 +53,9 @@ When you run `archgate check`, the CLI loads every ADR that has `rules: true` in
   </Card>
   <Card title="Self-Governance" icon="approve-check-circle">
     Archgate governs its own development. The same tool that checks your code
-    checks ours. Six ADRs enforce command structure, error handling, output
-    formatting, testing, and more.
+    checks ours. Our own ADRs enforce command structure, error handling, output
+    formatting, testing, and more — [see them on
+    GitHub](https://github.com/archgate/cli/tree/main/.archgate/adrs).
   </Card>
 </CardGrid>
 

--- a/docs/src/content/docs/pt-br/index.mdx
+++ b/docs/src/content/docs/pt-br/index.mdx
@@ -53,8 +53,9 @@ Quando você executa `archgate check`, a CLI carrega cada ADR que possui `rules:
   </Card>
   <Card title="Auto-Governança" icon="approve-check-circle">
     O Archgate governa seu próprio desenvolvimento. A mesma ferramenta que
-    verifica seu código verifica o nosso. Seis ADRs aplicam estrutura de
-    comandos, tratamento de erros, formatação de saída, testes e mais.
+    verifica seu código verifica o nosso. Nossos próprios ADRs aplicam estrutura
+    de comandos, tratamento de erros, formatação de saída, testes e mais — [veja
+    no GitHub](https://github.com/archgate/cli/tree/main/.archgate/adrs).
   </Card>
 </CardGrid>
 


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Removed the full command table, hardcoded ADR list (ARCH-001–GEN-002), and pinned tool versions — replaced with references to `src/commands/`, `.archgate/adrs/`, and `.prototools`
- **README.md**: Removed the commands table and CI/pre-commit section — these duplicate the docs site at cli.archgate.dev
- **Homepage (en + pt-br)**: Replaced "Six ADRs" with open-ended wording and added a link to the ADRs directory on GitHub

## Test plan
- [x] `bun run validate` passes
- [ ] Verify docs site renders correctly with updated card text