### PR TITLE
feat: support Git Bash PATH setup in install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ When a rule is violated, `archgate check` reports the file, line, and which ADR 
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+curl -fsSL https://cli.archgate.dev/install-unix | sh
 
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex
+irm https://cli.archgate.dev/install-windows | iex
+
+# Windows (Git Bash / MSYS2)
+curl -fsSL https://cli.archgate.dev/install-unix | sh
 ```
 
 **Via npm** (or any Node.js package manager):
@@ -77,7 +80,7 @@ npx archgate check         # run via package manager
 
 ```bash
 # 1. Install
-curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh  # or: npm install -g archgate
+curl -fsSL https://cli.archgate.dev/install-unix | sh  # or: npm install -g archgate
 
 # 2. Initialize governance in your project
 cd my-project

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,0 +1,3 @@
+# Install script redirects
+/install-unix https://raw.githubusercontent.com/archgate/cli/main/install.sh 302
+/install-windows https://raw.githubusercontent.com/archgate/cli/main/install.ps1 302

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -126,9 +126,14 @@ curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
 
 # Windows (PowerShell)
 irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex
+
+# Windows (Git Bash / MSYS2)
+curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
 ```
 
 This downloads a pre-built binary for your platform and installs it to `~/.archgate/bin/`. The installer detects your shell profiles and offers to add the directory to your PATH.
+
+On Windows, the PowerShell installer also detects Git Bash shell profiles (`.bashrc`, `.bash_profile`, `.profile`) and offers to configure PATH there as well.
 
 You can customize the install with environment variables:
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -122,13 +122,13 @@ The fastest way to install Archgate — no Node.js or package manager required:
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+curl -fsSL https://cli.archgate.dev/install-unix | sh
 
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex
+irm https://cli.archgate.dev/install-windows | iex
 
 # Windows (Git Bash / MSYS2)
-curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+curl -fsSL https://cli.archgate.dev/install-unix | sh
 ```
 
 This downloads a pre-built binary for your platform and installs it to `~/.archgate/bin/`. The installer detects your shell profiles and offers to add the directory to your PATH.
@@ -264,7 +264,7 @@ If you have not installed the CLI yet:
 
 ```bash
 # Standalone (no Node.js required)
-curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+curl -fsSL https://cli.archgate.dev/install-unix | sh
 
 # Or via npm
 npm install -g archgate
@@ -1018,7 +1018,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+      - run: curl -fsSL https://cli.archgate.dev/install-unix | sh
       - run: ~/.archgate/bin/archgate check --ci
 ```
 

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -13,9 +13,14 @@ curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
 
 # Windows (PowerShell)
 irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex
+
+# Windows (Git Bash / MSYS2)
+curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
 ```
 
 This downloads a pre-built binary for your platform and installs it to `~/.archgate/bin/`. The installer detects your shell profiles and offers to add the directory to your PATH.
+
+On Windows, the PowerShell installer also detects Git Bash shell profiles (`.bashrc`, `.bash_profile`, `.profile`) and offers to configure PATH there as well.
 
 You can customize the install with environment variables:
 

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -9,13 +9,13 @@ The fastest way to install Archgate — no Node.js or package manager required:
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+curl -fsSL https://cli.archgate.dev/install-unix | sh
 
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex
+irm https://cli.archgate.dev/install-windows | iex
 
 # Windows (Git Bash / MSYS2)
-curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+curl -fsSL https://cli.archgate.dev/install-unix | sh
 ```
 
 This downloads a pre-built binary for your platform and installs it to `~/.archgate/bin/`. The installer detects your shell profiles and offers to add the directory to your PATH.

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -9,7 +9,7 @@ If you have not installed the CLI yet:
 
 ```bash
 # Standalone (no Node.js required)
-curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+curl -fsSL https://cli.archgate.dev/install-unix | sh
 
 # Or via npm
 npm install -g archgate

--- a/docs/src/content/docs/guides/ci-integration.mdx
+++ b/docs/src/content/docs/guides/ci-integration.mdx
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+      - run: curl -fsSL https://cli.archgate.dev/install-unix | sh
       - run: ~/.archgate/bin/archgate check --ci
 ```
 

--- a/docs/src/content/docs/pt-br/getting-started/installation.mdx
+++ b/docs/src/content/docs/pt-br/getting-started/installation.mdx
@@ -13,9 +13,14 @@ curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
 
 # Windows (PowerShell)
 irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex
+
+# Windows (Git Bash / MSYS2)
+curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
 ```
 
 Isso baixa um binário pré-compilado para sua plataforma e instala em `~/.archgate/bin/`. O instalador detecta os perfis do seu shell e oferece adicionar o diretório ao seu PATH.
+
+No Windows, o instalador PowerShell também detecta perfis de shell do Git Bash (`.bashrc`, `.bash_profile`, `.profile`) e oferece configurar o PATH neles.
 
 Você pode personalizar a instalação com variáveis de ambiente:
 

--- a/docs/src/content/docs/pt-br/getting-started/installation.mdx
+++ b/docs/src/content/docs/pt-br/getting-started/installation.mdx
@@ -9,13 +9,13 @@ A forma mais rápida de instalar o Archgate — sem necessidade de Node.js ou ge
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+curl -fsSL https://cli.archgate.dev/install-unix | sh
 
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/archgate/cli/main/install.ps1 | iex
+irm https://cli.archgate.dev/install-windows | iex
 
 # Windows (Git Bash / MSYS2)
-curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+curl -fsSL https://cli.archgate.dev/install-unix | sh
 ```
 
 Isso baixa um binário pré-compilado para sua plataforma e instala em `~/.archgate/bin/`. O instalador detecta os perfis do seu shell e oferece adicionar o diretório ao seu PATH.

--- a/docs/src/content/docs/pt-br/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/pt-br/getting-started/quick-start.mdx
@@ -9,7 +9,7 @@ Se você ainda não instalou a CLI:
 
 ```bash
 # Standalone (sem necessidade de Node.js)
-curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+curl -fsSL https://cli.archgate.dev/install-unix | sh
 
 # Ou via npm
 npm install -g archgate

--- a/docs/src/content/docs/pt-br/guides/ci-integration.mdx
+++ b/docs/src/content/docs/pt-br/guides/ci-integration.mdx
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
+      - run: curl -fsSL https://cli.archgate.dev/install-unix | sh
       - run: ~/.archgate/bin/archgate check --ci
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -93,5 +93,49 @@ if ($CurrentPath -notlike "*$InstallDir*") {
     Write-Host "Restart your terminal for the change to take effect in new sessions."
 }
 
+# --- Update Git Bash / MSYS2 shell profiles ---
+
+$GitBashProfiles = @()
+foreach ($f in @("$HOME\.bashrc", "$HOME\.bash_profile", "$HOME\.profile")) {
+    if (Test-Path $f) {
+        $GitBashProfiles += $f
+        break
+    }
+}
+
+$InstallDirPosix = $InstallDir -replace '\\', '/' -replace '^([A-Za-z]):', '/$1'
+$PathLine = "export PATH=`"$InstallDirPosix:`$PATH`""
+
+$NeedsUpdate = @()
+foreach ($f in $GitBashProfiles) {
+    if (-not (Select-String -Path $f -SimpleMatch $InstallDirPosix -Quiet)) {
+        $NeedsUpdate += $f
+    }
+}
+
+if ($NeedsUpdate.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Detected Git Bash shell profiles to update:"
+    foreach ($f in $NeedsUpdate) {
+        Write-Host "  $f  ->  $PathLine"
+    }
+    Write-Host ""
+
+    $answer = Read-Host "Update these files now? [Y/n]"
+    if ($answer -match '^[nN]') {
+        Write-Host ""
+        Write-Host "Skipped. To add manually, append this line to your shell profile:"
+        Write-Host ""
+        Write-Host "  $PathLine"
+    } else {
+        foreach ($f in $NeedsUpdate) {
+            Add-Content -Path $f -Value "`n# archgate`n$PathLine"
+            Write-Host "  Updated: $f"
+        }
+        Write-Host ""
+        Write-Host "Restart Git Bash for the change to take effect."
+    }
+}
+
 Write-Host ""
 Write-Host "Run 'archgate --help' to get started."

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Archgate installer for macOS and Linux
+# Archgate installer for macOS, Linux, and Windows (Git Bash / MSYS2)
 # Usage: curl -fsSL https://raw.githubusercontent.com/archgate/cli/main/install.sh | sh
 set -eu
 
@@ -13,11 +13,12 @@ detect_platform() {
   arch="$(uname -m)"
 
   case "$os" in
-    Darwin) platform="darwin" ;;
-    Linux)  platform="linux" ;;
+    Darwin)       platform="darwin" ;;
+    Linux)        platform="linux" ;;
+    MINGW*|MSYS*) platform="win32" ;;
     *)
       echo "Error: unsupported OS: $os" >&2
-      echo "archgate supports macOS (ARM64) and Linux (x86_64)." >&2
+      echo "archgate supports macOS (ARM64), Linux (x86_64), and Windows (x64)." >&2
       exit 1
       ;;
   esac
@@ -39,6 +40,10 @@ detect_platform() {
   fi
   if [ "$platform" = "linux" ] && [ "$arch" != "x64" ]; then
     echo "Error: Linux is only supported on x86_64." >&2
+    exit 1
+  fi
+  if [ "$platform" = "win32" ] && [ "$arch" != "x64" ]; then
+    echo "Error: Windows is only supported on x86_64." >&2
     exit 1
   fi
 
@@ -98,7 +103,13 @@ resolve_version() {
 # --- Download and install ---
 
 download_and_install() {
-  url="https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT}.tar.gz"
+  if [ "$platform" = "win32" ]; then
+    ext="zip"
+  else
+    ext="tar.gz"
+  fi
+
+  url="https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT}.${ext}"
 
   echo "Installing archgate ${VERSION} (${ARTIFACT})..."
 
@@ -106,18 +117,24 @@ download_and_install() {
   trap 'rm -rf "$tmpdir"' EXIT
 
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$url" -o "$tmpdir/archgate.tar.gz"
+    curl -fsSL "$url" -o "$tmpdir/archgate.${ext}"
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO "$tmpdir/archgate.tar.gz" "$url"
+    wget -qO "$tmpdir/archgate.${ext}" "$url"
   else
     echo "Error: neither 'curl' nor 'wget' is installed. Please install one of them to download archgate." >&2
     exit 1
   fi
 
-  tar -xzf "$tmpdir/archgate.tar.gz" -C "$tmpdir"
   mkdir -p "$INSTALL_DIR"
-  mv "$tmpdir/archgate" "$INSTALL_DIR/archgate"
-  chmod +x "$INSTALL_DIR/archgate"
+
+  if [ "$platform" = "win32" ]; then
+    unzip -qo "$tmpdir/archgate.zip" -d "$tmpdir"
+    mv "$tmpdir/archgate.exe" "$INSTALL_DIR/archgate.exe"
+  else
+    tar -xzf "$tmpdir/archgate.tar.gz" -C "$tmpdir"
+    mv "$tmpdir/archgate" "$INSTALL_DIR/archgate"
+    chmod +x "$INSTALL_DIR/archgate"
+  fi
 }
 
 # --- Update PATH ---
@@ -272,7 +289,11 @@ main() {
   resolve_version
   download_and_install
 
-  echo "archgate ${VERSION} installed to ${INSTALL_DIR}/archgate"
+  if [ "$platform" = "win32" ]; then
+    echo "archgate ${VERSION} installed to ${INSTALL_DIR}/archgate.exe"
+  else
+    echo "archgate ${VERSION} installed to ${INSTALL_DIR}/archgate"
+  fi
   setup_path
 
   echo ""


### PR DESCRIPTION
## Summary

- **install.sh**: Add MINGW/MSYS2 platform detection so `install.sh` can run directly from Git Bash on Windows — downloads the `.zip` artifact and installs `archgate.exe`
- **install.ps1**: After updating the Windows User PATH, detect Git Bash shell profiles (`~/.bashrc`, `~/.bash_profile`, `~/.profile`) and offer to add a POSIX-formatted `export PATH` line

Fixes the issue where `archgate` was not found in Git Bash sessions after installing via PowerShell, because the Windows PATH update doesn't always propagate to Git Bash shell profiles.

## Test plan

- [ ] Run `install.ps1` on a Windows machine with Git Bash installed and a `~/.profile` — verify it prompts to update the shell profile
- [ ] Run `install.ps1` on a Windows machine without any bash profiles — verify no Git Bash section is shown
- [ ] Run `install.sh` from Git Bash (MINGW64) — verify it detects `win32` platform, downloads `.zip`, and installs `archgate.exe`
- [ ] Verify idempotency: run installer twice — second run should skip already-configured profiles