### PR TITLE
fix: correct Windows drive letter casing and platform error message

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -66,6 +66,7 @@ jobs:
         shell: pwsh
         env:
           ARCHGATE_VERSION: ${{ vars.LATEST_RELEASE_TAG || '' }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Resolve version: use ARCHGATE_VERSION if set, otherwise query GitHub
           if (-not $env:ARCHGATE_VERSION) {
@@ -117,6 +118,7 @@ jobs:
       - name: Smoke test install.sh
         env:
           ARCHGATE_VERSION: ${{ vars.LATEST_RELEASE_TAG || '' }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Resolve version: use ARCHGATE_VERSION if set, otherwise query GitHub
           if [ -z "$ARCHGATE_VERSION" ]; then

--- a/install.ps1
+++ b/install.ps1
@@ -104,7 +104,7 @@ foreach ($f in @("$HOME\.bashrc", "$HOME\.bash_profile", "$HOME\.profile")) {
 }
 
 $InstallDirPosix = $InstallDir -replace '\\', '/' -replace '^([A-Za-z]):', { '/' + $args[0].Groups[1].Value.ToLower() }
-$PathLine = "export PATH=`"$InstallDirPosix:`$PATH`""
+$PathLine = "export PATH=`"${InstallDirPosix}:`$PATH`""
 
 $NeedsUpdate = @()
 foreach ($f in $GitBashProfiles) {

--- a/install.ps1
+++ b/install.ps1
@@ -103,7 +103,7 @@ foreach ($f in @("$HOME\.bashrc", "$HOME\.bash_profile", "$HOME\.profile")) {
     }
 }
 
-$InstallDirPosix = $InstallDir -replace '\\', '/' -replace '^([A-Za-z]):', '/$1'
+$InstallDirPosix = $InstallDir -replace '\\', '/' -replace '^([A-Za-z]):', { '/' + $args[0].Groups[1].Value.ToLower() }
 $PathLine = "export PATH=`"$InstallDirPosix:`$PATH`""
 
 $NeedsUpdate = @()

--- a/install.ps1
+++ b/install.ps1
@@ -103,7 +103,10 @@ foreach ($f in @("$HOME\.bashrc", "$HOME\.bash_profile", "$HOME\.profile")) {
     }
 }
 
-$InstallDirPosix = $InstallDir -replace '\\', '/' -replace '^([A-Za-z]):', { '/' + $args[0].Groups[1].Value.ToLower() }
+$InstallDirPosix = $InstallDir -replace '\\', '/'
+if ($InstallDirPosix -match '^([A-Za-z]):') {
+    $InstallDirPosix = '/' + $Matches[1].ToLower() + $InstallDirPosix.Substring(2)
+}
 $PathLine = "export PATH=`"${InstallDirPosix}:`$PATH`""
 
 $NeedsUpdate = @()

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ detect_platform() {
     x86_64|amd64)  arch="x64" ;;
     *)
       echo "Error: unsupported architecture: $arch" >&2
-      echo "archgate supports arm64 (macOS) and x64 (Linux)." >&2
+      echo "archgate supports arm64 (macOS) and x64 (Linux, Windows)." >&2
       exit 1
       ;;
   esac

--- a/install.sh
+++ b/install.sh
@@ -253,14 +253,17 @@ setup_path() {
   done
   echo ""
 
-  # Prompt requires /dev/tty — available even when stdin is piped (curl | sh)
-  if [ ! -r /dev/tty ]; then
-    echo "No readable TTY available. To add archgate to your PATH manually, add the lines above to your shell profile."
+  # Prompt requires /dev/tty — available even when stdin is piped (curl | sh).
+  # Test with an actual open, not just -r, because CI runners may report it as
+  # readable yet fail to open it (no controlling terminal).
+  if ! exec 3</dev/tty 2>/dev/null; then
+    echo "No TTY available. To add archgate to your PATH manually, add the lines above to your shell profile."
     return
   fi
+  exec 3<&-
 
   printf "Update these files now? [Y/n] "
-  if ! read -r answer </dev/tty; then
+  if ! read -r answer </dev/tty 2>/dev/null; then
     echo ""
     echo "Could not read from terminal. To add archgate to your PATH manually, add the lines above to your shell profile."
     return

--- a/install.sh
+++ b/install.sh
@@ -254,13 +254,12 @@ setup_path() {
   echo ""
 
   # Prompt requires /dev/tty — available even when stdin is piped (curl | sh).
-  # Test with an actual open, not just -r, because CI runners may report it as
-  # readable yet fail to open it (no controlling terminal).
-  if ! exec 3</dev/tty 2>/dev/null; then
+  # Use a subshell to test the actual open, because -r may pass on CI runners
+  # that have /dev/tty present but no controlling terminal.
+  if ! (exec </dev/tty) 2>/dev/null; then
     echo "No TTY available. To add archgate to your PATH manually, add the lines above to your shell profile."
     return
   fi
-  exec 3<&-
 
   printf "Update these files now? [Y/n] "
   if ! read -r answer </dev/tty 2>/dev/null; then


### PR DESCRIPTION
## Summary
- **install.ps1**: Fix POSIX path conversion to lowercase the drive letter (`C:` → `/c` instead of `/C`), matching Git Bash conventions
- **install.sh**: Include Windows in the unsupported architecture error message for consistency with actual platform support

## Test plan
- [ ] Run `install.ps1` on Windows and verify the Git Bash PATH entry uses a lowercase drive letter (e.g., `/c/Users/...`)
- [ ] Trigger the unsupported architecture error in `install.sh` and confirm the message mentions Windows