### PR TITLE
chore: add archgate proto plugin to .prototools

### DIFF
--- a/.prototools
+++ b/.prototools
@@ -11,4 +11,5 @@ auto-clean = true
 shared-globals-dir = true
 
 [plugins.tools]
+archgate = "github://archgate/proto-plugin"
 gh = "https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/gh/plugin.toml"


### PR DESCRIPTION
## Summary
- Registers the archgate proto WASM plugin so the Archgate CLI can be installed via `proto install archgate`