### PR TITLE
fix: treat rule import failures as errors

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -29,7 +29,15 @@ export function registerCheckCommand(program: Command) {
         process.exit(1);
       }
 
-      const loadedAdrs = await loadRuleAdrs(projectRoot, opts.adr);
+      let loadedAdrs;
+      try {
+        loadedAdrs = await loadRuleAdrs(projectRoot, opts.adr);
+      } catch (err) {
+        logError(
+          err instanceof Error ? err.message : `Failed to load rules: ${err}`
+        );
+        process.exit(1);
+      }
 
       if (loadedAdrs.length === 0) {
         if (opts.json) {

--- a/src/engine/loader.ts
+++ b/src/engine/loader.ts
@@ -22,7 +22,7 @@ const RuleSetSchema = z.object({
     })
   ),
 });
-import { logDebug, logWarn } from "../helpers/log";
+import { logDebug } from "../helpers/log";
 import { projectPaths } from "../helpers/paths";
 import { ensureRulesShim } from "../helpers/rules-shim";
 
@@ -90,30 +90,24 @@ export async function loadRuleAdrs(
         );
       }
 
-      try {
-        // Cache-bust: Bun caches import() per-process, so append a timestamp
-        // to force re-reading from disk on every call (critical for repeated invocations).
-        // Use file:// URL to handle Windows backslash paths in import().
-        const rulesUrl = `${pathToFileURL(rulesFile).href}?t=${Date.now()}`;
-        const mod = await import(rulesUrl);
-        const parsed = RuleSetSchema.safeParse(mod.default);
+      // Cache-bust: Bun caches import() per-process, so append a timestamp
+      // to force re-reading from disk on every call (critical for repeated invocations).
+      // Use file:// URL to handle Windows backslash paths in import().
+      const rulesUrl = `${pathToFileURL(rulesFile).href}?t=${Date.now()}`;
+      const mod = await import(rulesUrl);
+      const parsed = RuleSetSchema.safeParse(mod.default);
 
-        if (!parsed.success) {
-          logWarn(
-            `ADR ${adr.frontmatter.id}: companion file does not export a valid RuleSet as default`
-          );
-          return null;
-        }
-
-        const ruleSet: RuleSet = parsed.data;
-        logDebug(
-          `Loaded ${Object.keys(ruleSet.rules).length} rules from ${adr.frontmatter.id}`
+      if (!parsed.success) {
+        throw new Error(
+          `ADR ${adr.frontmatter.id}: companion file does not export a valid RuleSet as default`
         );
-        return { adr, ruleSet };
-      } catch (err) {
-        logWarn(`Failed to import rules for ${adr.frontmatter.id}: ${err}`);
-        return null;
       }
+
+      const ruleSet: RuleSet = parsed.data;
+      logDebug(
+        `Loaded ${Object.keys(ruleSet.rules).length} rules from ${adr.frontmatter.id}`
+      );
+      return { adr, ruleSet };
     })
   );
 


### PR DESCRIPTION
## Summary
- Rule files that fail to import (e.g., missing `archgate/rules` module) were silently logged as warnings and skipped, causing `archgate check` to exit 0 with "No rules to check"
- Now `loadRuleAdrs` throws on import failures instead of swallowing errors, and the `check` command catches them and exits with code 1
- Fixes the issue seen in [archgate/website#14](https://github.com/archgate/website/actions/runs/23348557761/job/67920603825?pr=14) where rule import errors appeared as warnings but the check still passed

## Test plan
- [x] `bun run validate` passes
- [ ] Verify on a project with broken rule imports that `archgate check` now exits 1