### PR TITLE
chore: pin gh CLI to 2.88.1 in prototools

### DIFF
--- a/.prototools
+++ b/.prototools
@@ -1,7 +1,7 @@
 bun = "1.3.9"
 node = "24"
 npm = "11.11.0"
-gh = "^2.83.2"
+gh = "2.88.1"
 
 [settings]
 auto-install = true


### PR DESCRIPTION
## Summary
- Pin `gh` version in `.prototools` from `^2.83.2` to `2.88.1` for reproducible toolchain builds

## Test plan
- [ ] Verify `proto install gh` installs 2.88.1