### PR TITLE
fix(config): unify docs dependencies into a single Renovate PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,14 @@
       "matchPackageNames": ["oven-sh/bun", "@types/bun"]
     },
     {
+      "description": "Group CLI devDependencies (minor/patch) into a single PR",
+      "groupName": "cli devDependencies (non-major)",
+      "matchFileNames": ["package.json"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackageNames": ["@types/bun"]
+    },
+    {
       "description": "Group all docs dependencies (Astro, Starlight, etc.) into a single PR",
       "groupName": "docs dependencies",
       "matchFileNames": ["docs/package.json"],

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,8 @@
     {
       "description": "Group all docs dependencies (Astro, Starlight, etc.) into a single PR",
       "groupName": "docs dependencies",
-      "matchFileNames": ["docs/package.json"]
+      "matchFileNames": ["docs/package.json"],
+      "separateMajorMinor": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Renovate was creating two separate PRs for docs dependencies — one for minor updates (`@astrojs/starlight`) and one for major updates (`astro`) — because `separateMajorMinor` defaults to `true`
- Added a `docs dependencies` grouping rule with `separateMajorMinor: false` so all `docs/package.json` updates land in a single PR
- The previous attempt only had `matchFileNames` + `groupName` but was missing `separateMajorMinor: false`, which is required to prevent Renovate from splitting major vs non-major into separate branches

## Test plan
- [ ] Verify Renovate creates a single PR for all docs dependency updates (trigger via Dependency Dashboard checkbox)
- [ ] Confirm PR #126 and #127 get superseded by a unified PR on next Renovate run