### PR TITLE
fix: encode colons and dots in session-context project path

### DIFF
--- a/src/helpers/session-context.ts
+++ b/src/helpers/session-context.ts
@@ -5,18 +5,33 @@ import { basename, join } from "node:path";
 import { isWSL, toWindowsPath } from "./platform";
 
 /**
- * Encode a project root path into the directory name used by Claude/Cursor.
- * In WSL, converts to Windows path first so the encoded name matches
- * what Windows-side Claude/Cursor uses.
+ * Encode a project root path into the directory name used by Claude/Cursor
+ * for storing session files under `~/.claude/projects/` or `~/.cursor/projects/`.
+ *
+ * Replaces path separators (`\`, `/`), drive-letter colons (`:`), and dots (`.`)
+ * with dashes (`-`) to match the encoding Claude Code and Cursor use internally.
+ *
+ * Examples:
+ * - `/home/user/project`          → `-home-user-project`
+ * - `C:\Users\user\project`       → `C--Users-user-project`
+ * - `E:\foo\.claude\worktrees\x`  → `E--foo--claude-worktrees-x`
+ *
+ * In WSL, converts to the Windows path first so the encoded name matches
+ * what the Windows-side editor uses.
  */
 export async function encodeProjectPath(projectRoot: string): Promise<string> {
+  let raw = projectRoot;
   if (isWSL()) {
     const winPath = await toWindowsPath(projectRoot);
     if (winPath) {
-      return winPath.replaceAll("\\", "-").replaceAll("/", "-");
+      raw = winPath;
     }
   }
-  return projectRoot.replaceAll("\\", "-").replaceAll("/", "-");
+  return raw
+    .replaceAll("\\", "-")
+    .replaceAll("/", "-")
+    .replaceAll(":", "-")
+    .replaceAll(".", "-");
 }
 
 const RELEVANT_TYPES = new Set(["user", "assistant"]);

--- a/tests/helpers/session-context-cursor.test.ts
+++ b/tests/helpers/session-context-cursor.test.ts
@@ -13,7 +13,11 @@ describe("readCursorSession", () => {
   // homedir() caching on Linux doesn't break the tests.
   const uniqueId = `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const projectRoot = `/__archgate_cursor_test_${uniqueId}`;
-  const encodedProject = projectRoot.replaceAll("/", "-");
+  const encodedProject = projectRoot
+    .replaceAll("/", "-")
+    .replaceAll("\\", "-")
+    .replaceAll(":", "-")
+    .replaceAll(".", "-");
   let transcriptsDir: string;
 
   beforeEach(() => {

--- a/tests/helpers/session-context.test.ts
+++ b/tests/helpers/session-context.test.ts
@@ -30,16 +30,30 @@ describe("encodeProjectPath", () => {
     expect(await encodeProjectPath("/a//b")).toBe("-a--b");
   });
 
-  test("replaces backslashes with dashes (Windows paths)", async () => {
+  test("replaces backslashes and colons with dashes (Windows paths)", async () => {
     expect(await encodeProjectPath("C:\\Users\\user\\project")).toBe(
-      "C:-Users-user-project"
+      "C--Users-user-project"
     );
   });
 
   test("handles mixed slashes", async () => {
     expect(await encodeProjectPath("C:\\Users/user\\project")).toBe(
-      "C:-Users-user-project"
+      "C--Users-user-project"
     );
+  });
+
+  test("replaces dots with dashes", async () => {
+    expect(await encodeProjectPath("/home/user/.config/project")).toBe(
+      "-home-user--config-project"
+    );
+  });
+
+  test("encodes Windows worktree path (colons, backslashes, dots)", async () => {
+    expect(
+      await encodeProjectPath(
+        "E:\\archgate\\cli\\.claude\\worktrees\\fancy-prancing-sedgewick"
+      )
+    ).toBe("E--archgate-cli--claude-worktrees-fancy-prancing-sedgewick");
   });
 });
 
@@ -62,7 +76,11 @@ describe("readClaudeCodeSession", () => {
     // homedir() caching on Linux doesn't break the tests.
     const uniqueId = `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const projectRoot = `/__archgate_test_${uniqueId}`;
-    const encodedProject = projectRoot.replaceAll("/", "-");
+    const encodedProject = projectRoot
+      .replaceAll("/", "-")
+      .replaceAll("\\", "-")
+      .replaceAll(":", "-")
+      .replaceAll(".", "-");
     let projectsDir: string;
 
     beforeEach(() => {


### PR DESCRIPTION
## Summary

- `encodeProjectPath()` only replaced `\` and `/` with `-`, but Claude Code and Cursor also replace `:` and `.` when creating project session directories under `~/.claude/projects/`
- On Windows, `session-context claude-code` would look for `E:-archgate-cli-.claude-worktrees-x` instead of the actual `E--archgate-cli--claude-worktrees-x`, causing "No session files found"
- Added `:` and `.` to the replacement set to match the editor's encoding, and documented the full character mapping in JSDoc

## Test plan

- [x] Existing `encodeProjectPath` tests updated — Windows path now expects `C--Users-user-project` (colon replaced)
- [x] New test: dots replaced (`/home/user/.config/project` → `-home-user--config-project`)
- [x] New test: exact Windows worktree path (`E:\archgate\cli\.claude\worktrees\fancy-prancing-sedgewick`) encodes correctly
- [x] Test fixtures in `session-context.test.ts` and `session-context-cursor.test.ts` use the updated encoding
- [x] `bun run validate` passes (457 tests, 21/21 ADR checks)