### PR TITLE
fix(ci): post status checks on release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,11 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: write
   contents: write
   id-token: write
   pull-requests: write
+  statuses: write
 
 jobs:
   check:
@@ -83,10 +85,23 @@ jobs:
           workflow: pull-request
           github-token: ${{ github.token }}
           branch: release
-  validate-release-pr:
-    name: Validate release PR
-    needs: pull-request
-    uses: ./.github/workflows/code-pull-request.yml
+      - name: Run CI and set status checks on release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          HEAD_SHA=$(gh api repos/${{ github.repository }}/git/ref/heads/release --jq '.object.sha')
+
+          gh workflow run code-pull-request.yml --ref release
+          sleep 5
+          RUN_ID=$(gh run list --branch release --workflow code-pull-request.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+          echo "Waiting for CI run $RUN_ID..."
+          gh run watch "$RUN_ID" --exit-status && STATUS=success || STATUS=failure
+
+          gh api repos/${{ github.repository }}/statuses/$HEAD_SHA \
+            -f state="$STATUS" \
+            -f context="Validate Code" \
+            -f description="CI $STATUS" \
+            --silent
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Summary
- Replace the `validate-release-pr` reusable workflow call with direct CI triggering + commit status posting
- Add `actions: write` and `statuses: write` permissions to the release workflow
- After creating/updating the release PR, the workflow now triggers `code-pull-request.yml` on the `release` branch via `gh workflow run`, waits for completion, and posts a "Validate Code" commit status on the release branch HEAD

This fixes the issue where release PRs required manually triggering the validate workflow because:
1. PRs created with `GITHUB_TOKEN` don't trigger other workflows (GitHub security)
2. Reusable `workflow_call` check names don't match branch protection's expected "Validate Code" check

Ported from the same fix in [bun-serve-compress#10](https://github.com/rhuanbarreto/bun-serve-compress/pull/10).

## Test plan
- [ ] Merge and verify the next release PR gets status checks automatically and is mergeable without manual intervention