### PR TITLE
fix(ci): skip release PR validation when branch missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          HEAD_SHA=$(gh api repos/${{ github.repository }}/git/ref/heads/release --jq '.object.sha')
+          HEAD_SHA=$(gh api repos/${{ github.repository }}/git/ref/heads/release --jq '.object.sha' 2>/dev/null) || true
+
+          if [ -z "$HEAD_SHA" ]; then
+            echo "No release branch found — nothing to validate"
+            exit 0
+          fi
 
           gh workflow run code-pull-request.yml --ref release
           sleep 5


### PR DESCRIPTION
## Summary
- When `simple-release-action` finds no releasable commits (e.g. only `chore` pushes), it succeeds without creating the `release` branch
- The subsequent CI-trigger step then fails with a 404 on `gh api .../git/ref/heads/release`
- Guard against this by checking the branch exists before triggering CI; exit cleanly if absent

Fixes https://github.com/archgate/cli/actions/runs/23392177826/job/68048701479

## Test plan
- [ ] Push a non-releasable commit (e.g. `chore`) to `main` and verify the release workflow succeeds