### PR TITLE
fix: copilot CLI plugin install uses wrong URL and command

### DIFF
--- a/src/commands/plugin/install.ts
+++ b/src/commands/plugin/install.ts
@@ -65,12 +65,15 @@ export function registerPluginInstallCommand(plugin: Command) {
               await installCopilotPlugin();
               logInfo(`Archgate plugin installed for ${label}.`);
             } else {
-              const url = buildMarketplaceUrl();
+              const url = buildVscodeMarketplaceUrl();
               logWarn(
                 "Copilot CLI not found. To install the plugin manually, run:"
               );
               console.log(
-                `  ${styleText("bold", "copilot plugin install")} ${url}`
+                `  ${styleText("bold", "copilot plugin marketplace add")} ${url}`
+              );
+              console.log(
+                `  ${styleText("bold", "copilot plugin install")} archgate@archgate`
               );
             }
             break;

--- a/src/helpers/plugin-install.ts
+++ b/src/helpers/plugin-install.ts
@@ -164,16 +164,30 @@ export async function isCopilotCliAvailable(): Promise<boolean> {
  * Install the archgate plugin via the `copilot` CLI.
  *
  * Runs:
- *   copilot plugin install <authenticated-git-url>
+ *   copilot plugin marketplace add <vscode-marketplace-url>
+ *   copilot plugin install archgate@archgate
  *
  * Throws on failure so the caller can fall back to manual instructions.
  */
 export async function installCopilotPlugin(): Promise<void> {
-  const url = buildMarketplaceUrl();
+  const url = buildVscodeMarketplaceUrl();
   const cmd = (await resolveCommand("copilot")) ?? "copilot";
 
+  logDebug("Adding archgate marketplace to copilot CLI");
+  const addResult = await run([cmd, "plugin", "marketplace", "add", url]);
+  if (addResult.exitCode !== 0) {
+    throw new Error(
+      `copilot plugin marketplace add failed (exit ${addResult.exitCode})`
+    );
+  }
+
   logDebug("Installing archgate plugin via copilot CLI");
-  const installResult = await run([cmd, "plugin", "install", url]);
+  const installResult = await run([
+    cmd,
+    "plugin",
+    "install",
+    "archgate@archgate",
+  ]);
   if (installResult.exitCode !== 0) {
     throw new Error(
       `copilot plugin install failed (exit ${installResult.exitCode})`


### PR DESCRIPTION
## Summary

- **Fixed wrong git URL**: `installCopilotPlugin()` was using `archgate.git` (Claude Code `.claude-plugin/` format) instead of `archgate-vscode.git` (`.github/plugin/` format that copilot CLI expects)
- **Fixed install command**: Changed from single `copilot plugin install <url>` (which fails because the repo is a marketplace, not a flat plugin) to two-step `copilot plugin marketplace add` + `copilot plugin install archgate@archgate` (matching the working Claude Code pattern)
- **Fixed manual fallback**: Updated the fallback instructions shown when copilot CLI is not found to use the correct marketplace commands

## Test plan

- [ ] Run `archgate plugin install --editor copilot` with copilot CLI available — verify it runs `marketplace add` then `install archgate@archgate`
- [ ] Run `archgate plugin install --editor copilot` without copilot CLI — verify fallback prints correct `copilot plugin marketplace add` + `copilot plugin install archgate@archgate` commands
- [ ] Verify `archgate plugin install --editor claude` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)