### PR TITLE
fix: prevent release push race condition

### DIFF
--- a/.archgate/adrs/GEN-003-tool-invocation-via-scripts.md
+++ b/.archgate/adrs/GEN-003-tool-invocation-via-scripts.md
@@ -43,12 +43,12 @@ All linting, formatting, and validation MUST be invoked through `package.json` s
 
 **Required scripts**: Every `package.json` that contains lintable or formattable source code MUST define at minimum:
 
-| Script | Purpose |
-|--------|---------|
-| `lint` | Run the project's linter with project-specific flags |
-| `format` | Run the project's formatter in write mode |
-| `format:check` | Run the project's formatter in check mode (CI-safe) |
-| `validate` | Run the full validation suite (lint + format:check + typecheck + test + any other checks) |
+| Script         | Purpose                                                                                   |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| `lint`         | Run the project's linter with project-specific flags                                      |
+| `format`       | Run the project's formatter in write mode                                                 |
+| `format:check` | Run the project's formatter in check mode (CI-safe)                                       |
+| `validate`     | Run the full validation suite (lint + format:check + typecheck + test + any other checks) |
 
 ## Do's and Don'ts
 
@@ -87,7 +87,7 @@ All linting, formatting, and validation MUST be invoked through `package.json` s
 ### Risks
 
 - **Missing scripts in new repositories**: A new Archgate repository might omit the required scripts, causing agents to fall back to direct invocation. **Mitigation:** The `archgate init` scaffolding MUST include these scripts in the generated `package.json`. Code review MUST verify their presence in any new `package.json` file.
-- **Script divergence across repos**: The `validate` script may have different steps in different repos (e.g., some include `bun run build:check`, others don't), creating inconsistent validation depth. **Mitigation:** This is acceptable — each repository's `validate` script reflects its specific needs. The invariant is that `bun run validate` always runs the *complete* set of checks for that repository.
+- **Script divergence across repos**: The `validate` script may have different steps in different repos (e.g., some include `bun run build:check`, others don't), creating inconsistent validation depth. **Mitigation:** This is acceptable — each repository's `validate` script reflects its specific needs. The invariant is that `bun run validate` always runs the _complete_ set of checks for that repository.
 
 ## Compliance and Enforcement
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,8 @@ jobs:
       - name: Validate
         id: validate
         run: bun run validate
+      - name: Ensure main is up-to-date before release
+        run: git pull --rebase origin main
       - name: Release
         uses: TrigenSoftware/simple-release-action@v1
         with:


### PR DESCRIPTION
## Summary

- Adds `git pull --rebase origin main` before the release step in the release workflow
- Prevents non-fast-forward push failures when PRs are merged during the release workflow

## Problem

The release workflow checks out `main` at the start, then runs validate + release. If a PR is merged between checkout and the final `git push main` (done internally by `simple-release-action`), the push is rejected as non-fast-forward. This happened during the v0.22.0 release when GEN-003 (#149) was merged during the release window.

## Fix

A `git pull --rebase` right before the release step ensures the local checkout includes any commits that landed on `main` since the workflow started. The release action's push is then guaranteed to be fast-forward.

## Test plan

- [ ] CI passes
- [ ] Next release completes without push failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)