### PR TITLE
fix(ci): remove self-referencing archgate proto plugin

### DIFF
--- a/.prototools
+++ b/.prototools
@@ -11,5 +11,4 @@ auto-clean = true
 shared-globals-dir = true
 
 [plugins.tools]
-archgate = "github://archgate/proto-plugin"
 gh = "https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/gh/plugin.toml"


### PR DESCRIPTION
## Summary
- Remove `archgate = "github://archgate/proto-plugin"` from `.prototools`
- The CLI repo IS archgate — having it listed as a proto plugin creates a circular dependency where `moonrepo/setup-toolchain` tries to install archgate to build archgate
- This caused the darwin-arm64 release build to fail with `proto install` exit code 1

## Test plan
- [ ] CI passes without `proto install` failures on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)