### PR TITLE
fix: avoid Windows CI timeout in init idempotency test

### DIFF
--- a/tests/integration/init.test.ts
+++ b/tests/integration/init.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { initProject } from "../../src/helpers/init-project";
 import { safeRmSync } from "../test-utils";
 import { runCli, createTempProject } from "./cli-harness";
 
@@ -80,11 +81,13 @@ describe("init integration", () => {
   });
 
   test("init is idempotent — second run succeeds and does not duplicate example ADR", async () => {
-    await runCli(["init", "--editor", "claude"], tempDir, isolatedEnv());
+    // First init via direct call (avoids a second subprocess cold-start on Windows CI)
+    await initProject(tempDir, { editor: "claude" });
 
     const adrsDir = join(tempDir, ".archgate", "adrs");
     const adrsBefore = readdirSync(adrsDir).filter((f) => f.endsWith(".md"));
 
+    // Second init via CLI — the actual idempotency assertion
     const result = await runCli(
       ["init", "--editor", "claude"],
       tempDir,


### PR DESCRIPTION
## Summary

- The `init is idempotent` integration test spawned two `bun run` subprocesses sequentially, each cold-starting Bun + TypeScript on Windows (~3.5s each), exceeding the default 5000ms timeout
- Replaced the first `runCli()` call with a direct `initProject()` import for setup, keeping only the second call as a real CLI subprocess for the idempotency assertion
- Cuts test time roughly in half while preserving end-to-end coverage

## Test plan

- [x] `bun run validate` passes locally (545 tests, 22/22 ADR checks)
- [ ] Windows CI job passes without timeout