### PR TITLE
docs: add studies section to sidebar navigation

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -257,6 +257,11 @@ export default defineConfig({
           collapsed: true,
           autogenerate: { directory: "examples" },
         },
+        {
+          label: "Studies",
+          collapsed: true,
+          autogenerate: { directory: "studies" },
+        },
       ],
     }),
   ],


### PR DESCRIPTION
Adds a Studies section to the Starlight docs sidebar, auto-generated from the studies directory.

Made with [Cursor](https://cursor.com)