### PR TITLE
fix: use correct path encoding for Cursor session-context on Windows

### DIFF
--- a/src/helpers/session-context.ts
+++ b/src/helpers/session-context.ts
@@ -2,24 +2,34 @@ import { readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 
+import type { EditorTarget } from "./init-project";
 import { isWSL, toWindowsPath } from "./platform";
 
 /**
  * Encode a project root path into the directory name used by Claude/Cursor
  * for storing session files under `~/.claude/projects/` or `~/.cursor/projects/`.
  *
- * Replaces path separators (`\`, `/`), drive-letter colons (`:`), and dots (`.`)
- * with dashes (`-`) to match the encoding Claude Code and Cursor use internally.
+ * Replaces path separators (`\`, `/`) and dots (`.`) with dashes (`-`).
+ * Drive-letter colons (`:`) are handled per-tool: Claude Code replaces them
+ * with dashes while Cursor strips them entirely.
  *
- * Examples:
+ * Examples (target = "claude", the default):
  * - `/home/user/project`          → `-home-user-project`
  * - `C:\Users\user\project`       → `C--Users-user-project`
  * - `E:\foo\.claude\worktrees\x`  → `E--foo--claude-worktrees-x`
  *
+ * Examples (target = "cursor"):
+ * - `/home/user/project`          → `-home-user-project`
+ * - `C:\Users\user\project`       → `C-Users-user-project`
+ * - `E:\foo\.claude\worktrees\x`  → `E-foo--claude-worktrees-x`
+ *
  * In WSL, converts to the Windows path first so the encoded name matches
  * what the Windows-side editor uses.
  */
-export async function encodeProjectPath(projectRoot: string): Promise<string> {
+export async function encodeProjectPath(
+  projectRoot: string,
+  target?: EditorTarget
+): Promise<string> {
   let raw = projectRoot;
   if (isWSL()) {
     const winPath = await toWindowsPath(projectRoot);
@@ -27,10 +37,11 @@ export async function encodeProjectPath(projectRoot: string): Promise<string> {
       raw = winPath;
     }
   }
+  const colonReplacement = target === "cursor" ? "" : "-";
   return raw
     .replaceAll("\\", "-")
     .replaceAll("/", "-")
-    .replaceAll(":", "-")
+    .replaceAll(":", colonReplacement)
     .replaceAll(".", "-");
 }
 
@@ -177,7 +188,10 @@ export async function readCursorSession(
   options?: ReadCursorSessionOptions
 ): Promise<CursorSessionResult> {
   const limit = options?.maxEntries ?? 200;
-  const encodedPath = await encodeProjectPath(projectRoot ?? process.cwd());
+  const encodedPath = await encodeProjectPath(
+    projectRoot ?? process.cwd(),
+    "cursor"
+  );
   const transcriptsDir = join(
     homedir(),
     ".cursor",

--- a/tests/helpers/session-context-cursor.test.ts
+++ b/tests/helpers/session-context-cursor.test.ts
@@ -16,7 +16,7 @@ describe("readCursorSession", () => {
   const encodedProject = projectRoot
     .replaceAll("/", "-")
     .replaceAll("\\", "-")
-    .replaceAll(":", "-")
+    .replaceAll(":", "")
     .replaceAll(".", "-");
   let transcriptsDir: string;
 

--- a/tests/helpers/session-context.test.ts
+++ b/tests/helpers/session-context.test.ts
@@ -55,6 +55,34 @@ describe("encodeProjectPath", () => {
       )
     ).toBe("E--archgate-cli--claude-worktrees-fancy-prancing-sedgewick");
   });
+
+  test("cursor target strips colons instead of replacing with dashes", async () => {
+    expect(await encodeProjectPath("C:\\Users\\user\\project", "cursor")).toBe(
+      "C-Users-user-project"
+    );
+  });
+
+  test("cursor target handles mixed slashes", async () => {
+    expect(await encodeProjectPath("C:\\Users/user\\project", "cursor")).toBe(
+      "C-Users-user-project"
+    );
+  });
+
+  test("cursor target encodes Windows worktree path", async () => {
+    expect(
+      await encodeProjectPath(
+        "E:\\archgate\\cli\\.claude\\worktrees\\fancy-prancing-sedgewick",
+        "cursor"
+      )
+    ).toBe("E-archgate-cli--claude-worktrees-fancy-prancing-sedgewick");
+  });
+
+  test("cursor target produces same result as default for Unix paths", async () => {
+    const unixPath = "/home/user/project";
+    expect(await encodeProjectPath(unixPath, "cursor")).toBe(
+      await encodeProjectPath(unixPath)
+    );
+  });
 });
 
 describe("readClaudeCodeSession", () => {


### PR DESCRIPTION
## Summary

- Cursor and Claude Code encode Windows drive-letter colons differently in their project directory names: Claude Code replaces `:` with `-` (`C--Users-...`) while Cursor strips them entirely (`C-Users-...`).
- The shared `encodeProjectPath` only implemented the Claude Code scheme, so `archgate session-context cursor` always failed on Windows with *No Cursor agent-transcripts directory found*.
- Added a `target` option (`claude` | `cursor`) to `encodeProjectPath` so each caller selects the correct encoding. Default remains `claude` (backward-compatible).

## Test plan

- [x] All 30 existing + new tests pass (`bun test`)
- [x] 4 new tests cover Cursor-target encoding for Windows paths, mixed slashes, worktree paths, and Unix path equivalence
- [ ] Manual: run `archgate session-context cursor` on Windows and verify it finds the agent-transcripts directory

Made with [Cursor](https://cursor.com)