### PR TITLE
fix: use VS Code marketplace URL in copilot init fallback

### DIFF
--- a/src/helpers/init-project.ts
+++ b/src/helpers/init-project.ts
@@ -268,8 +268,7 @@ async function tryInstallPlugin(editor: EditorTarget): Promise<PluginResult> {
       isCopilotCliAvailable,
       installCopilotPlugin,
       buildVscodeMarketplaceUrl,
-    } =
-      await import("./plugin-install");
+    } = await import("./plugin-install");
 
     if (await isCopilotCliAvailable()) {
       try {

--- a/src/helpers/init-project.ts
+++ b/src/helpers/init-project.ts
@@ -264,7 +264,11 @@ async function tryInstallPlugin(editor: EditorTarget): Promise<PluginResult> {
   }
 
   if (editor === "copilot") {
-    const { isCopilotCliAvailable, installCopilotPlugin, buildMarketplaceUrl } =
+    const {
+      isCopilotCliAvailable,
+      installCopilotPlugin,
+      buildVscodeMarketplaceUrl,
+    } =
       await import("./plugin-install");
 
     if (await isCopilotCliAvailable()) {
@@ -276,7 +280,7 @@ async function tryInstallPlugin(editor: EditorTarget): Promise<PluginResult> {
       }
     }
 
-    const url = buildMarketplaceUrl();
+    const url = buildVscodeMarketplaceUrl();
     return { installed: true, detail: url };
   }
 


### PR DESCRIPTION
## Summary
- fixes `archgate init --editor copilot --install-plugin` fallback messaging to return the Copilot-compatible marketplace URL
- switches Copilot fallback in `init-project` from Claude marketplace URL to VS Code/Copilot marketplace URL
- keeps Cursor and VS Code init/install flows unchanged

## Test plan
- [x] Run `bun test tests/helpers/init-project.test.ts tests/commands/init.test.ts`
- [x] Confirm no lint issues in `src/helpers/init-project.ts`
- [x] Verify diff vs `main` only contains `src/helpers/init-project.ts`