### PR TITLE
chore: use shared org-level Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,36 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Extract bun version from .prototools",
-      "managerFilePatterns": ["/^\\.prototools$/"],
-      "matchStrings": ["bun\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "oven-sh/bun",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^bun-v(?<version>.+)$"
-    }
-  ],
-  "packageRules": [
-    {
-      "description": "Group Bun runtime (.prototools) and @types/bun together",
-      "groupName": "bun",
-      "matchPackageNames": ["oven-sh/bun", "@types/bun"]
-    },
-    {
-      "description": "Group CLI devDependencies (minor/patch) into a single PR",
-      "groupName": "cli devDependencies (non-major)",
-      "matchFileNames": ["package.json"],
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchPackageNames": ["!@types/bun"]
-    },
-    {
-      "description": "Group all docs dependencies (Astro, Starlight, etc.) into a single PR",
-      "groupName": "docs dependencies",
-      "matchFileNames": ["docs/package.json"],
-      "separateMajorMinor": false
-    }
-  ]
+  "extends": ["local>archgate/renovate-config"]
 }


### PR DESCRIPTION
## Summary

- Replace repo-specific Renovate config with a reference to the new shared [`archgate/renovate-config`](https://github.com/archgate/renovate-config) preset
- All security hardening, grouping, automerge, and scheduling policies are now centralized

### What moves to the shared config
- `config:best-practices` base (was `config:recommended`)
- Bun `.prototools` custom manager + `@types/bun` grouping
- DevDependencies non-major grouping
- Docs dependencies grouping
- Security: OpenSSF scorecard, OSV vuln alerts, GitHub Actions SHA pinning, 3-day npm release age
- Automerge for linters/formatters/types on minor/patch
- Major update dashboard approval
- Non-office-hours schedule, rate limiting

## Test plan

- [ ] Renovate picks up the shared config on next scheduled run
- [ ] Dependency dashboard issue is created/updated
- [ ] Existing open Renovate PRs are rebased with new grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)