### PR TITLE
fix: address valid AI quality findings

### DIFF
--- a/docs/src/content/docs/pt-br/studies/sentry-pr-review-friction-and-adr-pack.mdx
+++ b/docs/src/content/docs/pt-br/studies/sentry-pr-review-friction-and-adr-pack.mdx
@@ -21,13 +21,13 @@ Leia a publicação canônica (metodologia, métricas, índice de ADRs) em:
 
 Alinhado à [metodologia](https://studies.archgate.dev/studies/sentry-pr-review-friction/methodology/) do estudo publicado:
 
-| Conjunto de dados          | Contagem                                           |
-| -------------------------- | -------------------------------------------------- |
-| PRs mesclados              | 500                                                |
-| PRs fechados sem merge     | 500                                                |
-| PRs abertos amostrados     | 251                                                |
-| Análise profunda de coment | 60 PRs de alto atrito (50 mesclados + 10 fechados) |
-| Comentários coletados      | 965 no total (604 não-bot)                         |
+| Conjunto de dados               | Contagem                                           |
+| ------------------------------- | -------------------------------------------------- |
+| PRs mesclados                   | 500                                                |
+| PRs fechados sem merge          | 500                                                |
+| PRs abertos amostrados          | 251                                                |
+| Análise profunda de comentários | 60 PRs de alto atrito (50 mesclados + 10 fechados) |
+| Comentários coletados           | 965 no total (604 não-bot)                         |
 
 Os dados vêm da API do GitHub (veja a página de metodologia para comandos `gh` exatos, pontuação de atrito e limitações).
 

--- a/src/helpers/init-project.ts
+++ b/src/helpers/init-project.ts
@@ -5,6 +5,7 @@ import { generateExampleAdr } from "./adr-templates";
 import { configureClaudeSettings } from "./claude-settings";
 import { configureCopilotSettings } from "./copilot-settings";
 import { configureCursorSettings } from "./cursor-settings";
+import { logDebug } from "./log";
 import { createPathIfNotExists, projectPaths } from "./paths";
 import { writeRulesShim } from "./rules-shim";
 import { configureVscodeSettings } from "./vscode-settings";
@@ -230,7 +231,11 @@ async function tryInstallPlugin(editor: EditorTarget): Promise<PluginResult> {
   const { loadCredentials } = await import("./credential-store");
   const credentials = await loadCredentials();
   if (!credentials) {
-    return { installed: false };
+    return {
+      installed: false,
+      detail:
+        "No stored credentials found; plugin installation was not attempted.",
+    };
   }
 
   if (editor === "cursor") {
@@ -244,8 +249,9 @@ async function tryInstallPlugin(editor: EditorTarget): Promise<PluginResult> {
       try {
         await installCursorPlugin(credentials.token);
         return { installed: true, autoInstalled: true };
-      } catch {
+      } catch (error) {
         // Fall through to manual instructions
+        logDebug("Failed to auto-install Cursor plugin:", error);
       }
     }
 
@@ -274,8 +280,9 @@ async function tryInstallPlugin(editor: EditorTarget): Promise<PluginResult> {
       try {
         await installCopilotPlugin();
         return { installed: true, autoInstalled: true };
-      } catch {
+      } catch (error) {
         // Fall through to manual instructions
+        logDebug("Failed to auto-install Copilot plugin:", error);
       }
     }
 
@@ -291,8 +298,9 @@ async function tryInstallPlugin(editor: EditorTarget): Promise<PluginResult> {
     try {
       await installClaudePlugin();
       return { installed: true, autoInstalled: true };
-    } catch {
+    } catch (error) {
       // Fall through to manual instructions
+      logDebug("Failed to auto-install Claude plugin:", error);
     }
   }
 


### PR DESCRIPTION
## Summary

Reviewed all 12 AI findings from GitHub's Code Quality AI scanner and triaged them by validity. This PR addresses the ones worth fixing:

- **Fix PT-BR typo**: Corrected truncated word `coment` → `comentários` in the Sentry study translation table
- **Improve plugin install observability**: Added `logDebug()` calls to the three silent catch blocks in `tryInstallPlugin()` (Cursor, Copilot, Claude) so auto-install failures are visible in debug mode while preserving the intentional fall-through to manual URLs
- **Add detail to missing credentials**: The `{ installed: false }` return now includes a `detail` explaining why installation was skipped

### Dismissed findings (not addressed)

| Finding | Reason |
|---------|--------|
| Replace `Bun.env` with `process.env` in `paths.ts` | **Violates ADR ARCH-014** — project mandates `Bun.env` in all `src/` files |
| Add max depth to `findProjectRoot` | **False positive** — `dirname()` terminates at filesystem root (`parent === dir`), no infinite loop possible |
| 4x test coverage suggestions for `url.test.ts` | Wrong scope — structural unit tests don't need integration-level URL output verification |
| Use `randomUUID` in test uniqueId | Cosmetic — `Date.now() + Math.random()` is adequate for test isolation |

## Test plan

- [x] `bun run validate` passes (lint, typecheck, format, 603 tests, ADR check, build)
- [x] ARCH-014 ADR check specifically passes (no `process.env` in `src/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)