### PR TITLE
ci: add daily workflow to track .archgate adoption via PostHog

### DIFF
--- a/.github/workflows/track-adoption.yml
+++ b/.github/workflows/track-adoption.yml
@@ -47,6 +47,8 @@ jobs:
             ')
 
           repo_count=$(jq 'length' <<< "$repos_json")
+          file_count=$(gh api -X GET search/code -f q='path:.archgate/' --jq '.total_count')
+
           echo "repo_count=$repo_count" >> "$GITHUB_OUTPUT"
           {
             echo "repos_json<<EOF"
@@ -54,7 +56,15 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-          echo "::notice::Found $repo_count public repos"
+          echo "::notice::Found $repo_count public repos ($file_count file matches)"
+
+          # GitHub code search caps results at 1000 per query. Beyond that, the
+          # repo count plateaus silently. Warn early so we shard before saturating.
+          if [ "$file_count" -ge 1000 ]; then
+            echo "::error::File match count is ${file_count} — AT the 1000-result search cap. Repo discovery is now incomplete; shard the query (see comment above) before trusting this data."
+          elif [ "$file_count" -ge 800 ]; then
+            echo "::warning::File match count is ${file_count} — approaching the 1000-result search cap. Plan query sharding before we saturate."
+          fi
 
       - name: Send per-repo events to PostHog
         env:

--- a/.github/workflows/track-adoption.yml
+++ b/.github/workflows/track-adoption.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   track:
-    name: Count .archgate adopters on GitHub
+    name: Emit per-repo adoption events
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -33,48 +33,71 @@ jobs:
           repos_json=$(gh search code 'path:.archgate/' \
             --limit 1000 \
             --json repository \
-            --jq '[.[] | select(.repository.isPrivate == false) | .repository.nameWithOwner] | unique')
+            --jq '
+              [.[].repository]
+              | map(select(.isPrivate == false))
+              | unique_by(.nameWithOwner)
+              | map({
+                  full_name: .nameWithOwner,
+                  owner: (.nameWithOwner | split("/")[0]),
+                  name: (.nameWithOwner | split("/")[1]),
+                  url: .url,
+                  is_fork: .isFork
+                })
+            ')
 
           repo_count=$(jq 'length' <<< "$repos_json")
-          file_count=$(gh api -X GET search/code -f q='path:.archgate/' --jq '.total_count')
-
           echo "repo_count=$repo_count" >> "$GITHUB_OUTPUT"
-          echo "file_count=$file_count" >> "$GITHUB_OUTPUT"
           {
             echo "repos_json<<EOF"
             echo "$repos_json"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-          echo "::notice::Found $repo_count public repos ($file_count file matches)"
+          echo "::notice::Found $repo_count public repos"
 
-      - name: Send event to PostHog
+      - name: Send per-repo events to PostHog
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ vars.POSTHOG_HOST || 'https://eu.i.posthog.com' }}
-          REPO_COUNT: ${{ steps.search.outputs.repo_count }}
-          FILE_COUNT: ${{ steps.search.outputs.file_count }}
           REPOS_JSON: ${{ steps.search.outputs.repos_json }}
         run: |
           set -euo pipefail
 
+          timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          # One event per repo, batched into a single PostHog call.
+          # distinct_id = "owner/name" makes each repo a "person" in PostHog,
+          # so first-seen / last-seen and per-repo timelines come for free.
+          # $set populates the person properties so the Persons view is useful.
           payload=$(jq -n \
             --arg api_key "$POSTHOG_API_KEY" \
-            --argjson repo_count "$REPO_COUNT" \
-            --argjson file_count "$FILE_COUNT" \
+            --arg timestamp "$timestamp" \
             --argjson repos "$REPOS_JSON" \
             '{
               api_key: $api_key,
-              event: "github_repos_count",
-              distinct_id: "archgate-github-tracker",
-              properties: {
-                repo_count: $repo_count,
-                file_count: $file_count,
-                repos: $repos,
-                "$lib": "github-actions"
-              }
+              batch: ($repos | map({
+                event: "archgate_repo_seen",
+                distinct_id: .full_name,
+                timestamp: $timestamp,
+                properties: {
+                  owner: .owner,
+                  name: .name,
+                  full_name: .full_name,
+                  url: .url,
+                  is_fork: .is_fork,
+                  "$lib": "github-actions",
+                  "$set": {
+                    owner: .owner,
+                    name: .name,
+                    full_name: .full_name,
+                    url: .url,
+                    is_fork: .is_fork
+                  }
+                }
+              }))
             }')
 
-          curl -fsS -X POST "$POSTHOG_HOST/i/v0/e/" \
+          curl -fsS -X POST "$POSTHOG_HOST/batch/" \
             -H "Content-Type: application/json" \
             --data-binary "$payload"

--- a/.github/workflows/track-adoption.yml
+++ b/.github/workflows/track-adoption.yml
@@ -1,0 +1,80 @@
+name: Track adoption
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # daily at 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  track:
+    name: Count .archgate adopters on GitHub
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Search GitHub for .archgate/ folders
+        id: search
+        env:
+          # Classic PAT with `public_repo` scope. The default GITHUB_TOKEN is an
+          # app-installation token and is not guaranteed to work against the
+          # code-search API, which requires a user account.
+          GH_TOKEN: ${{ secrets.GH_SEARCH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Code search is capped at 1000 results per query. If we ever approach
+          # that, re-shard (e.g. by language or owner) before the count saturates.
+          repos_json=$(gh search code 'path:.archgate/' \
+            --limit 1000 \
+            --json repository \
+            --jq '[.[] | select(.repository.isPrivate == false) | .repository.nameWithOwner] | unique')
+
+          repo_count=$(jq 'length' <<< "$repos_json")
+          file_count=$(gh api -X GET search/code -f q='path:.archgate/' --jq '.total_count')
+
+          echo "repo_count=$repo_count" >> "$GITHUB_OUTPUT"
+          echo "file_count=$file_count" >> "$GITHUB_OUTPUT"
+          {
+            echo "repos_json<<EOF"
+            echo "$repos_json"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "::notice::Found $repo_count public repos ($file_count file matches)"
+
+      - name: Send event to PostHog
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST || 'https://eu.i.posthog.com' }}
+          REPO_COUNT: ${{ steps.search.outputs.repo_count }}
+          FILE_COUNT: ${{ steps.search.outputs.file_count }}
+          REPOS_JSON: ${{ steps.search.outputs.repos_json }}
+        run: |
+          set -euo pipefail
+
+          payload=$(jq -n \
+            --arg api_key "$POSTHOG_API_KEY" \
+            --argjson repo_count "$REPO_COUNT" \
+            --argjson file_count "$FILE_COUNT" \
+            --argjson repos "$REPOS_JSON" \
+            '{
+              api_key: $api_key,
+              event: "github_repos_count",
+              distinct_id: "archgate-github-tracker",
+              properties: {
+                repo_count: $repo_count,
+                file_count: $file_count,
+                repos: $repos,
+                "$lib": "github-actions"
+              }
+            }')
+
+          curl -fsS -X POST "$POSTHOG_HOST/i/v0/e/" \
+            -H "Content-Type: application/json" \
+            --data-binary "$payload"

--- a/.github/workflows/track-adoption.yml
+++ b/.github/workflows/track-adoption.yml
@@ -64,7 +64,29 @@ jobs:
         run: |
           set -euo pipefail
 
-          timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          date_utc=$(date -u +%Y-%m-%d)
+          timestamp="${date_utc}T$(date -u +%H:%M:%SZ)"
+
+          # Deterministic UUIDv5 per (event, UTC date, repo). PostHog dedupes
+          # events that share a uuid with a previously-ingested event, so a
+          # second workflow run on the same day (e.g. manual dispatch after
+          # the cron) is a no-op at ingestion.
+          uuids_json=$(python3 - "$date_utc" <<'PY'
+          import json, os, sys, uuid
+          date = sys.argv[1]
+          repos = json.loads(os.environ["REPOS_JSON"])
+          out = {
+              r["full_name"]: str(
+                  uuid.uuid5(
+                      uuid.NAMESPACE_URL,
+                      f"archgate_repo_seen:{date}:{r['full_name']}",
+                  )
+              )
+              for r in repos
+          }
+          print(json.dumps(out))
+          PY
+          )
 
           # One event per repo, batched into a single PostHog call.
           # distinct_id = "owner/name" makes each repo a "person" in PostHog,
@@ -74,11 +96,13 @@ jobs:
             --arg api_key "$POSTHOG_API_KEY" \
             --arg timestamp "$timestamp" \
             --argjson repos "$REPOS_JSON" \
+            --argjson uuids "$uuids_json" \
             '{
               api_key: $api_key,
               batch: ($repos | map({
                 event: "archgate_repo_seen",
                 distinct_id: .full_name,
+                uuid: $uuids[.full_name],
                 timestamp: $timestamp,
                 properties: {
                   owner: .owner,


### PR DESCRIPTION
## Summary
- New scheduled workflow (`.github/workflows/track-adoption.yml`) that runs daily at 08:00 UTC.
- Queries GitHub code-search for `path:.archgate/`, dedupes to unique **public** repos, and emits **one `archgate_repo_seen` event per repo** to PostHog's `/batch/` endpoint.
- `distinct_id = owner/name` — each repo becomes a PostHog "person", so first-seen / last-seen and per-repo timelines come for free. `$set` populates the person properties (`owner`, `name`, `full_name`, `url`, `is_fork`).
- Exposes `workflow_dispatch` for manual runs.

## How to chart cumulative adoption in PostHog
No ingestion-level dedup needed. Build a Trend insight:
- Event: `archgate_repo_seen`
- Math: **Unique users**
- Display: **Cumulative**

Each repo counts once regardless of how many events it's generated across daily runs.

## Required configuration
Before the first run will succeed, add these in **Settings → Secrets and variables → Actions**:

**Secrets**
- `GH_SEARCH_TOKEN` — classic PAT with `public_repo` scope. The default `GITHUB_TOKEN` is an app-installation token and isn't guaranteed to work against the code-search API.
- `POSTHOG_API_KEY` — PostHog **Project API Key** (the public `phc_...` token, not a personal key).

**Variables** (optional)
- `POSTHOG_HOST` — defaults to `https://eu.i.posthog.com`. Set if on US cloud or self-hosted.

## Caveats
- Code search skips very large / vendored files and non-default branches — the repo set is a lower bound.
- Results are capped at 1000 per query (currently ~300 file matches → ~3x headroom); re-shard before we saturate.
- `archgate/cli` itself counts toward the total since it contains `.archgate/`. Consistent day-over-day, just noting it.
- Treating each repo as a "person" conflates repos with real users if you later add user tracking to the same project. Easy migration to PostHog Groups later if that becomes an issue.

## Test plan
- [ ] Add `GH_SEARCH_TOKEN` and `POSTHOG_API_KEY` secrets.
- [ ] Trigger a manual run via the Actions tab (`workflow_dispatch`).
- [ ] Confirm the job logs the `::notice::Found N public repos` line.
- [ ] Confirm `archgate_repo_seen` events appear in PostHog live view (one per repo) with populated properties.
- [ ] Build the cumulative unique-users trend and verify it matches the count from the manual run.
- [ ] Wait for the first scheduled run to verify cron fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)