### PR TITLE
ci: suppress CLI telemetry in workflows

### DIFF
--- a/.github/workflows/code-pull-request.yml
+++ b/.github/workflows/code-pull-request.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  ARCHGATE_TELEMETRY: "0"
+
 jobs:
   validate:
     name: Lint, Test & Check

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: write
 
+env:
+  ARCHGATE_TELEMETRY: "0"
+
 jobs:
   build:
     name: Build ${{ matrix.artifact }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ permissions:
   pull-requests: write
   statuses: write
 
+env:
+  ARCHGATE_TELEMETRY: "0"
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test-linux.yml
+++ b/.github/workflows/smoke-test-linux.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: read
 
+env:
+  ARCHGATE_TELEMETRY: "0"
+
 jobs:
   linux:
     name: Linux

--- a/.github/workflows/smoke-test-windows.yml
+++ b/.github/workflows/smoke-test-windows.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: read
 
+env:
+  ARCHGATE_TELEMETRY: "0"
+
 jobs:
   windows:
     name: Windows

--- a/.github/workflows/update-llms.yaml
+++ b/.github/workflows/update-llms.yaml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  ARCHGATE_TELEMETRY: "0"
+
 jobs:
   update-llms:
     name: Update llms-full.txt

--- a/.github/workflows/update-lock.yaml
+++ b/.github/workflows/update-lock.yaml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  ARCHGATE_TELEMETRY: "0"
+
 jobs:
   update-lock:
     name: Update Package Lock


### PR DESCRIPTION
## Problem

CI workflows that build and run `archgate` from source were emitting PostHog telemetry tagged with in-development version strings from `package.json` (e.g. `v0.29.0-prerelease`). Each CI run looks like a real user installation in PostHog product-usage dashboards, inflating adoption numbers and polluting version distributions with prerelease tags that never ship.

## Fix

Set `ARCHGATE_TELEMETRY: "0"` as a top-level workflow `env:` block on every workflow that installs Bun or runs repo scripts. The CLI's `isEnvTelemetryDisabled()` short-circuits emission when this env var is set, so CI-from-source invocations (`bun run src/cli.ts`, `bunx archgate`, compiled smoke-test binaries) no longer reach PostHog. The env var is a no-op for workflows that don't invoke the CLI, so applying it broadly is safe.

## Files touched

Added `env.ARCHGATE_TELEMETRY: "0"`:

- `.github/workflows/code-pull-request.yml` — runs `bun run validate` (tests exercise CLI code paths)
- `.github/workflows/release-binaries.yml` — runs `bun run validate` and builds the CLI binary
- `.github/workflows/release.yml` — runs `bun run validate`
- `.github/workflows/smoke-test-linux.yml` — runs the compiled binary directly
- `.github/workflows/smoke-test-windows.yml` — runs the compiled binary directly
- `.github/workflows/update-llms.yaml` — runs a Bun script from the repo
- `.github/workflows/update-lock.yaml` — runs `bun install`

Skipped:

- `.github/workflows/track-adoption.yml` — pure `gh search` + `curl` to PostHog; does not install Bun or invoke the CLI. (This workflow is itself the intentional `archgate_repo_seen` event emitter.)