### PR TITLE
ci: improve OpenSSF Scorecard compliance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo
+* @rhuanbarreto

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -9,8 +9,7 @@ on:
         description: "Release tag to build (e.g. v0.1.0)"
         required: true
 
-permissions:
-  contents: write
+permissions: {}
 
 env:
   ARCHGATE_TELEMETRY: "0"
@@ -19,6 +18,8 @@ jobs:
   build:
     name: Build ${{ matrix.artifact }}
     timeout-minutes: 15
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,7 @@ concurrency:
   group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
-permissions:
-  actions: write
-  contents: write
-  id-token: write
-  pull-requests: write
-  statuses: write
+permissions: {}
 
 env:
   ARCHGATE_TELEMETRY: "0"
@@ -26,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Context check
+    permissions:
+      contents: read
     outputs:
       continue: ${{ steps.check.outputs.continue }}
       workflow: ${{ steps.check.outputs.workflow }}
@@ -64,6 +61,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Pull request
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      statuses: write
     needs: check
     if: needs.check.outputs.workflow == 'pull-request'
     steps:
@@ -114,6 +116,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Release
+    permissions:
+      contents: write
+      id-token: write
     needs: check
     if: needs.check.outputs.workflow == 'release'
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,9 +11,6 @@ on:
 
 permissions: read-all
 
-env:
-  ARCHGATE_TELEMETRY: "0"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Fixes the OpenSSF Scorecard workflow failure and addresses all actionable findings from the first scan.

### Scorecard workflow fix
- Remove global `env: ARCHGATE_TELEMETRY: "0"` block from `scorecard.yml` — the scorecard-action [rejects workflows with global env vars](https://github.com/ossf/scorecard-action#workflow-restrictions)

### Token-Permissions (0 → 10)
- `release-binaries.yml`: move `contents: write` from top-level to job-level
- `release.yml`: move all permissions from top-level to job-level, scoped per job:
  - **check**: `contents: read` only (uses app token for writes)
  - **pull-request**: `actions`, `contents`, `pull-requests`, `statuses: write`
  - **release**: `contents: write`, `id-token: write` (npm provenance)

### Branch-Protection
- Add `.github/CODEOWNERS` — the org ruleset requires codeowner review but no CODEOWNERS file existed

Pinned-Dependencies and Dependency-Update-Tool are handled by Renovate.

## Test plan
- [ ] Merge and verify the Scorecard workflow passes on the push-to-main trigger
- [ ] Verify the release workflow still works (next release cycle)
- [ ] Check updated score at https://scorecard.dev/viewer/?uri=github.com/archgate/cli