### PR TITLE
fix(ci): enable dco sign-off for renovate commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>archgate/renovate-config"]
+  "extends": ["local>archgate/renovate-config"],
+  "dco": true
 }


### PR DESCRIPTION
## Summary

- Add `"dco": true` to `renovate.json` so Renovate appends a `Signed-off-by` trailer to all its commits, satisfying the DCO workflow added in #233.

## Test plan

- [ ] Merge this PR, then verify the next Renovate PR has `Signed-off-by` in its commit messages