### PR TITLE
fix: remove invalid dco option from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>archgate/renovate-config"],
-  "dco": true
+  "extends": ["local>archgate/renovate-config"]
 }


### PR DESCRIPTION
## Summary
- Remove the invalid `"dco": true` option from `renovate.json` — this key doesn't exist in Renovate's config schema
- DCO sign-off is now handled org-wide via the `:gitSignOff` preset in `archgate/renovate-config` (see archgate/renovate-config#6)

## Test plan
- [ ] Renovate validates config without warnings about unknown options
- [ ] Next Renovate PR still includes `Signed-off-by` trailer (via org preset)