### PR TITLE
fix(ci): add SLSA provenance to release artifacts

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -116,3 +116,56 @@ jobs:
           $tag = "${{ github.event.release.tag_name || inputs.tag }}"
           Copy-Item "${{ steps.attest-win.outputs.bundle-path }}" "${{ matrix.artifact }}.zip.sigstore.json"
           gh release upload $tag "${{ matrix.artifact }}.zip" "${{ matrix.artifact }}.zip.sha256" "${{ matrix.artifact }}.zip.sigstore.json" --clobber
+
+      - name: Upload digest for SLSA provenance (Unix)
+        if: runner.os != 'Windows'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: digest-${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.tar.gz.sha256
+
+      - name: Upload digest for SLSA provenance (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: digest-${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.zip.sha256
+
+  combine-hashes:
+    name: Combine hashes for provenance
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      digests: ${{ steps.combine.outputs.digests }}
+    steps:
+      - name: Download all digest artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Combine digests
+        id: combine
+        run: |
+          echo "=== Individual digests ==="
+          cat *.sha256
+          echo ""
+          DIGESTS=$(cat *.sha256 | tr -d '\r' | base64 -w0)
+          echo "digests=$DIGESTS" >> "$GITHUB_OUTPUT"
+
+  # SLSA provenance — generates .intoto.jsonl and uploads it to the release.
+  # Uses tag ref (not SHA) because slsa-verifier checks the builder identity
+  # against a known tag list; SHA refs would fail verification.
+  provenance:
+    name: SLSA provenance
+    needs: combine-hashes
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: "${{ needs.combine-hashes.outputs.digests }}"
+      upload-assets: true
+      upload-tag-name: ${{ github.event.release.tag_name || inputs.tag }}


### PR DESCRIPTION
## Summary

- Adds SLSA v1.0 provenance generation via `slsa-framework/slsa-github-generator` generic workflow to `release-binaries.yml`
- Each platform build uploads its SHA256 digest as a GitHub Actions artifact; a `combine-hashes` job merges them; the `provenance` job calls the SLSA reusable workflow which generates `.intoto.jsonl` and uploads it to the GitHub Release
- Existing `actions/attest-build-provenance` steps are kept — they feed GitHub's Artifact Attestations API (`gh attestation verify`), while the new `.intoto.jsonl` files satisfy the OpenSSF Scorecard's Signed-Releases provenance tier (10/10 vs current 8/10)

## Context

[OpenSSF Scorecard](https://securityscorecards.dev/viewer/?uri=github.com/archgate/cli) currently gives **8/10** on Signed-Releases: all 5 latest releases have `.sigstore.json` signatures, but none have `.intoto.jsonl` SLSA provenance files. The Scorecard awards **10/10** only when `.intoto.jsonl` is present. Since the Scorecard checks the last 5 releases, the score will ramp up gradually with each new release.

## Test plan

- [ ] Merge and wait for next release — verify `release-binaries` workflow completes all 3 build jobs + `combine-hashes` + `provenance`
- [ ] Check the new release assets include a `multiple.intoto.jsonl` file alongside the existing `.sigstore.json` bundles
- [ ] Verify provenance with `slsa-verifier verify-artifact --provenance-path multiple.intoto.jsonl --source-uri github.com/archgate/cli <artifact>`
- [ ] After 1+ releases, re-check OpenSSF Scorecard Signed-Releases score (should increase above 8)