### PR TITLE
fix(init): hide opencode user-scope path from init output

### DIFF
--- a/src/helpers/init-project.ts
+++ b/src/helpers/init-project.ts
@@ -304,10 +304,6 @@ async function tryInstallPlugin(editor: EditorTarget): Promise<PluginResult> {
 
     try {
       await installOpencodePlugin(credentials.token);
-      // Intentionally omit `detail` — the resolved user-scope path is an
-      // implementation detail of the install. The init summary already shows
-      // an "(user-scope)" placeholder; surfacing the absolute path here is
-      // noise and leaks the user's home directory into stdout.
       return { installed: true, autoInstalled: true };
     } catch (error) {
       // Surface as a non-auto install so init routes through

--- a/src/helpers/init-project.ts
+++ b/src/helpers/init-project.ts
@@ -304,11 +304,11 @@ async function tryInstallPlugin(editor: EditorTarget): Promise<PluginResult> {
 
     try {
       await installOpencodePlugin(credentials.token);
-      return {
-        installed: true,
-        autoInstalled: true,
-        detail: opencodeAgentsDir(),
-      };
+      // Intentionally omit `detail` — the resolved user-scope path is an
+      // implementation detail of the install. The init summary already shows
+      // an "(user-scope)" placeholder; surfacing the absolute path here is
+      // noise and leaks the user's home directory into stdout.
+      return { installed: true, autoInstalled: true };
     } catch (error) {
       // Surface as a non-auto install so init routes through
       // `printManualInstructions("opencode", detail)`, which prints a


### PR DESCRIPTION
## Summary

- Stop printing the absolute opencode agents directory path during `archgate init` when the plugin is auto-installed
- The `(user-scope)` placeholder in the init summary already communicates that the install target is outside the project tree — the full resolved path (e.g. `C:\Users\<user>\.config\opencode\agents`) was unnecessary noise and leaked the user's home directory into stdout

## What changed

`src/helpers/init-project.ts` — the opencode branch in `tryInstallPlugin()` no longer sets `detail: opencodeAgentsDir()` on the success return. The `PluginResult` is returned with only `installed: true` and `autoInstalled: true`, so the init command prints the confirmation message without the path.

Error/fallback paths (cli-not-found, install failure) are unchanged — they still carry the relevant detail for `printManualInstructions()`.

## Test plan

- [ ] Run `archgate init --editor opencode --install-plugin` with opencode on PATH and verify the output shows "Archgate plugin installed for opencode." without an absolute path below it
- [ ] Run `archgate init --editor opencode --install-plugin` without opencode on PATH and verify the manual-install fallback still prints correctly
- [ ] Existing unit tests pass (`bun test tests/helpers/init-project.test.ts tests/commands/init.test.ts`)