### PR TITLE
refactor(cursor): remove project-level files, rely on VSIX-embedded plugin

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -66,7 +66,7 @@ function printConsole(report: DoctorReport): void {
       `  Claude:       ${bool(integrations.claude_plugin)} (.claude/settings.local.json)`
     );
     console.log(
-      `  Cursor:       ${bool(integrations.cursor_plugin)} (.cursor/rules/archgate-governance.mdc)`
+      `  Cursor:       ${bool(integrations.cursor_plugin)} (VSIX extension with embedded plugin)`
     );
     console.log(
       `  VS Code:      ${bool(integrations.vscode_settings)} (.vscode/settings.json)`

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -23,7 +23,9 @@ import { isTlsError, tlsHintMessage } from "../helpers/tls";
 
 const EDITOR_DIRS: Record<EditorTarget, string> = {
   claude: ".claude/",
-  cursor: ".cursor/",
+  // Cursor plugin is embedded in the VSIX extension — no project-level
+  // files are written. Shown as a label in the init summary.
+  cursor: "(VSIX)",
   vscode: ".vscode/",
   copilot: ".github/copilot/",
   // Opencode agents install to a user-scope directory, not the project tree.
@@ -227,8 +229,14 @@ function printManualInstructions(editor: EditorTarget, detail?: string): void {
         );
       }
       break;
+    case "cursor":
+      logWarn(
+        "Cursor CLI not found. To install the plugin manually:",
+        "Open Cursor → Ctrl+Shift+P → 'Extensions: Install from VSIX...' and select the archgate .vsix file."
+      );
+      break;
     default:
-      // cursor/vscode auto-install — should not reach here
+      // vscode auto-install — should not reach here
       break;
   }
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -230,10 +230,19 @@ function printManualInstructions(editor: EditorTarget, detail?: string): void {
       }
       break;
     case "cursor":
-      logWarn(
-        "Cursor CLI not found. To install the plugin manually:",
-        "Open Cursor → Ctrl+Shift+P → 'Extensions: Install from VSIX...' and select the archgate .vsix file."
-      );
+      if (detail && !detail.startsWith("download")) {
+        // detail is the VSIX path or the error message from installCursorPlugin
+        logWarn("Cursor CLI not found. The VSIX has been downloaded:");
+        console.log(`  ${styleText("bold", detail)}`);
+        console.log(
+          `  Open Cursor → Ctrl+Shift+P → ${styleText("bold", "Extensions: Install from VSIX...")} → select the file above`
+        );
+      } else {
+        logWarn(
+          "Could not download the VSIX. Retry with:",
+          `  ${styleText("bold", "archgate plugin install --editor cursor")}`
+        );
+      }
       break;
     default:
       // vscode auto-install — should not reach here

--- a/src/commands/plugin/install.ts
+++ b/src/commands/plugin/install.ts
@@ -14,7 +14,6 @@ import type { EditorTarget } from "../../helpers/init-project";
 import { logError, logInfo, logWarn } from "../../helpers/log";
 import { findProjectRoot, opencodeAgentsDir } from "../../helpers/paths";
 import {
-  buildCursorMarketplaceUrl,
   buildMarketplaceUrl,
   buildVscodeMarketplaceUrl,
   installClaudePlugin,
@@ -78,10 +77,9 @@ async function installForEditor(
         await installCursorPlugin(token);
         logInfo(`Archgate extension installed for ${label}.`);
       } else {
-        logWarn("Cursor CLI not found. To install the plugin manually:");
-        console.log(`  1. Install the VS Code extension in Cursor`);
-        console.log(
-          `  2. Add the Team Marketplace: ${buildCursorMarketplaceUrl()}`
+        logWarn(
+          "Cursor CLI not found. To install the plugin manually:",
+          "Open Cursor → Ctrl+Shift+P → 'Extensions: Install from VSIX...' and select the archgate .vsix file."
         );
       }
       break;
@@ -197,10 +195,10 @@ export function registerPluginInstallCommand(plugin: Command) {
               break;
             }
             case "cursor": {
-              const url = buildCursorMarketplaceUrl();
-              logInfo("To install the plugin manually:");
-              console.log(`  1. Install the VS Code extension in Cursor`);
-              console.log(`  2. Add the Team Marketplace: ${url}`);
+              logInfo(
+                "To install the plugin manually:",
+                "Open Cursor → Ctrl+Shift+P → 'Extensions: Install from VSIX...' and select the archgate .vsix file."
+              );
               break;
             }
             case "vscode": {

--- a/src/commands/plugin/install.ts
+++ b/src/commands/plugin/install.ts
@@ -16,6 +16,7 @@ import { findProjectRoot, opencodeAgentsDir } from "../../helpers/paths";
 import {
   buildMarketplaceUrl,
   buildVscodeMarketplaceUrl,
+  downloadVsix,
   installClaudePlugin,
   installCopilotPlugin,
   installCursorPlugin,
@@ -77,9 +78,11 @@ async function installForEditor(
         await installCursorPlugin(token);
         logInfo(`Archgate extension installed for ${label}.`);
       } else {
-        logWarn(
-          "Cursor CLI not found. To install the plugin manually:",
-          "Open Cursor → Ctrl+Shift+P → 'Extensions: Install from VSIX...' and select the archgate .vsix file."
+        const vsixPath = await downloadVsix(token);
+        logWarn("Cursor CLI not found. The VSIX has been downloaded:");
+        console.log(`  ${styleText("bold", vsixPath)}`);
+        console.log(
+          `  Open Cursor → Ctrl+Shift+P → ${styleText("bold", "Extensions: Install from VSIX...")} → select the file above`
         );
       }
       break;
@@ -195,9 +198,12 @@ export function registerPluginInstallCommand(plugin: Command) {
               break;
             }
             case "cursor": {
-              logInfo(
-                "To install the plugin manually:",
-                "Open Cursor → Ctrl+Shift+P → 'Extensions: Install from VSIX...' and select the archgate .vsix file."
+              logInfo("To install the plugin manually, run:");
+              console.log(
+                `  ${styleText("bold", "curl")} -H "Authorization: Bearer <token>" https://plugins.archgate.dev/api/vscode -o archgate.vsix`
+              );
+              console.log(
+                `  Then in Cursor: Ctrl+Shift+P → ${styleText("bold", "Extensions: Install from VSIX...")} → select archgate.vsix`
               );
               break;
             }

--- a/src/helpers/cursor-settings.ts
+++ b/src/helpers/cursor-settings.ts
@@ -1,64 +1,29 @@
-import { existsSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
-
 /**
- * Content for .cursor/rules/archgate-governance.mdc.
- * Uses alwaysApply: true so the agent always has governance context.
+ * Cursor editor integration.
+ *
+ * The archgate Cursor plugin (skills, agents, governance rules) is now
+ * embedded inside the VS Code extension (.vsix). When the extension
+ * activates in Cursor it calls `vscode.cursor.plugins.registerPath()`
+ * to expose the plugin — no project-level files are needed.
+ *
+ * `configureCursorSettings` is kept as a no-op for call-site
+ * compatibility (init-project.ts, etc.) and returns the `.cursor/`
+ * directory path for the init summary output.
  */
-export const ARCHGATE_CURSOR_RULE = `---
-description: Archgate ADR governance — enforces architecture decision records
-globs:
-alwaysApply: true
----
 
-# Archgate Governance
-
-This project uses Archgate to enforce Architecture Decision Records (ADRs).
-
-## Before writing code
-
-- Run \`archgate review-context\` to get applicable ADR briefings for changed files
-- Review the Decision and Do's/Don'ts sections of each applicable ADR
-
-## After writing code
-
-- Run \`archgate check --staged\` to validate compliance with all ADR rules
-- Fix any violations before considering work complete
-
-## ADR commands
-
-- \`archgate adr list\` — List all active ADRs with metadata
-- \`archgate check --staged\` — Run automated compliance checks
-- \`archgate review-context\` — Get changed files grouped by domain with ADR briefings
-
-## Key principle
-
-Architectural decisions are enforced, not suggested. If \`archgate check\` reports violations, they must be fixed.
-`;
+import { join } from "node:path";
 
 /**
  * Configure Cursor settings for archgate integration.
  *
- * Writes `.cursor/rules/archgate-governance.mdc` with always-on governance rule.
+ * No-op — the archgate VSIX extension embeds the Cursor plugin and
+ * registers it via `vscode.cursor.plugins.registerPath()` at runtime.
+ * No project-level files are written.
  *
- * @returns Absolute path to the rules file.
+ * @returns Path to the `.cursor/` directory (for init summary display).
  */
 export async function configureCursorSettings(
   projectRoot: string
 ): Promise<string> {
-  const cursorDir = join(projectRoot, ".cursor");
-  const rulesDir = join(cursorDir, "rules");
-  const rulePath = join(rulesDir, "archgate-governance.mdc");
-
-  // Ensure directories exist
-  if (!existsSync(cursorDir)) {
-    mkdirSync(cursorDir, { recursive: true });
-  }
-  if (!existsSync(rulesDir)) {
-    mkdirSync(rulesDir, { recursive: true });
-  }
-
-  await Bun.write(rulePath, ARCHGATE_CURSOR_RULE);
-
-  return rulePath;
+  return join(projectRoot, ".cursor");
 }

--- a/src/helpers/cursor-settings.ts
+++ b/src/helpers/cursor-settings.ts
@@ -22,8 +22,6 @@ import { join } from "node:path";
  *
  * @returns Path to the `.cursor/` directory (for init summary display).
  */
-export async function configureCursorSettings(
-  projectRoot: string
-): Promise<string> {
+export function configureCursorSettings(projectRoot: string): string {
   return join(projectRoot, ".cursor");
 }

--- a/src/helpers/doctor.ts
+++ b/src/helpers/doctor.ts
@@ -74,9 +74,11 @@ function detectIntegrations(): IntegrationInfo {
   const cwd = process.cwd();
   return {
     claudePlugin: existsSync(join(cwd, ".claude", "settings.local.json")),
-    cursorPlugin: existsSync(
-      join(cwd, ".cursor", "rules", "archgate-governance.mdc")
-    ),
+    // The Cursor plugin is embedded inside the archgate VS Code extension
+    // (.vsix) and registered at runtime via registerPath(). There is no
+    // project-level file to detect — report true when the cursor CLI exists
+    // (prerequisite for VSIX installation).
+    cursorPlugin: false, // resolved async below
     vscodeSettings: existsSync(join(cwd, ".vscode", "settings.json")),
     copilotSettings: existsSync(
       join(cwd, ".github", "copilot", "instructions.md")
@@ -102,6 +104,10 @@ export async function runDoctor(): Promise<DoctorReport> {
   ]);
 
   const editorMap = Object.fromEntries(editors.map((e) => [e.id, e.available]));
+
+  // Cursor plugin is embedded in the VSIX — no project file to detect.
+  // Use cursor CLI availability as a proxy (prerequisite for install).
+  integrations.cursorPlugin = Boolean(editorMap.cursor);
 
   return {
     system: {

--- a/src/helpers/init-project.ts
+++ b/src/helpers/init-project.ts
@@ -255,11 +255,8 @@ async function tryInstallPlugin(editor: EditorTarget): Promise<PluginResult> {
   }
 
   if (editor === "cursor") {
-    const {
-      isCursorCliAvailable,
-      installCursorPlugin,
-      buildCursorMarketplaceUrl,
-    } = await import("./plugin-install");
+    const { isCursorCliAvailable, installCursorPlugin } =
+      await import("./plugin-install");
 
     if (await isCursorCliAvailable()) {
       try {
@@ -271,8 +268,8 @@ async function tryInstallPlugin(editor: EditorTarget): Promise<PluginResult> {
       }
     }
 
-    const url = buildCursorMarketplaceUrl();
-    return { installed: true, detail: url };
+    // No cursor CLI — manual VSIX install needed
+    return { installed: false, detail: "cursor-cli-not-found" };
   }
 
   if (editor === "vscode") {

--- a/src/helpers/init-project.ts
+++ b/src/helpers/init-project.ts
@@ -255,7 +255,7 @@ async function tryInstallPlugin(editor: EditorTarget): Promise<PluginResult> {
   }
 
   if (editor === "cursor") {
-    const { isCursorCliAvailable, installCursorPlugin } =
+    const { isCursorCliAvailable, installCursorPlugin, downloadVsix } =
       await import("./plugin-install");
 
     if (await isCursorCliAvailable()) {
@@ -263,13 +263,23 @@ async function tryInstallPlugin(editor: EditorTarget): Promise<PluginResult> {
         await installCursorPlugin(credentials.token);
         return { installed: true, autoInstalled: true };
       } catch (error) {
-        // Fall through to manual instructions
+        // CLI install failed — VSIX is preserved on disk, error message has the path
         logDebug("Failed to auto-install Cursor plugin:", error);
+        return {
+          installed: true,
+          detail: error instanceof Error ? error.message : String(error),
+        };
       }
     }
 
-    // No cursor CLI — manual VSIX install needed
-    return { installed: false, detail: "cursor-cli-not-found" };
+    // No cursor CLI — download VSIX for manual install
+    try {
+      const vsixPath = await downloadVsix(credentials.token);
+      return { installed: true, detail: vsixPath };
+    } catch (error) {
+      logDebug("Failed to download Cursor VSIX:", error);
+      return { installed: false, detail: "download-failed" };
+    }
   }
 
   if (editor === "vscode") {

--- a/src/helpers/plugin-install.ts
+++ b/src/helpers/plugin-install.ts
@@ -148,7 +148,28 @@ async function downloadPluginAsset(
 // Cursor — download .vsix and install via `cursor` CLI
 // ---------------------------------------------------------------------------
 
-/** Install the archgate VS Code extension in Cursor via `cursor --install-extension`. */
+/**
+ * Download the archgate VSIX to `~/.archgate/archgate.vsix` without
+ * installing it. Returns the absolute path to the saved file. Used when
+ * the `cursor` CLI is not available so the user can install manually.
+ */
+export async function downloadVsix(token: string): Promise<string> {
+  const vsixPath = internalPath("archgate.vsix");
+  const buffer = await downloadPluginAsset("/api/vscode", token);
+  logDebug(
+    `Downloaded VS Code extension (${Math.round(buffer.byteLength / 1024)} KB)`
+  );
+  await Bun.write(vsixPath, buffer);
+  return vsixPath;
+}
+
+/**
+ * Install the archgate VS Code extension in Cursor via `cursor --install-extension`.
+ *
+ * On success the downloaded VSIX is cleaned up. On failure the VSIX is
+ * kept at `~/.archgate/archgate.vsix` so the user can install it manually
+ * via Cursor's "Extensions: Install from VSIX..." command.
+ */
 export async function installCursorPlugin(token: string): Promise<void> {
   const vsixPath = internalPath("archgate.vsix");
   const buffer = await downloadPluginAsset("/api/vscode", token);
@@ -157,21 +178,23 @@ export async function installCursorPlugin(token: string): Promise<void> {
   );
   await Bun.write(vsixPath, buffer);
 
+  const cursorCmd = (await resolveCommand("cursor")) ?? "cursor";
+  logDebug("Installing VS Code extension in Cursor via cursor CLI");
+  const result = await run([cursorCmd, "--install-extension", vsixPath]);
+  if (result.exitCode !== 0) {
+    // Keep the VSIX on disk so the user can install it manually
+    throw new Error(
+      `cursor --install-extension failed (exit ${result.exitCode}). ` +
+        `The VSIX was saved to ${vsixPath} — install it manually in Cursor: ` +
+        `Ctrl+Shift+P → "Extensions: Install from VSIX..."`
+    );
+  }
+
+  // Clean up only on success
   try {
-    const cursorCmd = (await resolveCommand("cursor")) ?? "cursor";
-    logDebug("Installing VS Code extension in Cursor via cursor CLI");
-    const result = await run([cursorCmd, "--install-extension", vsixPath]);
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `cursor --install-extension failed (exit ${result.exitCode})`
-      );
-    }
-  } finally {
-    try {
-      unlinkSync(vsixPath);
-    } catch {
-      // Ignore cleanup errors
-    }
+    unlinkSync(vsixPath);
+  } catch {
+    // Ignore cleanup errors
   }
 }
 
@@ -294,7 +317,12 @@ export async function isVscodeCliAvailable(): Promise<boolean> {
   return resolved !== null;
 }
 
-/** Download the .vsix from the plugins service and install via `code` CLI. */
+/**
+ * Download the .vsix from the plugins service and install via `code` CLI.
+ *
+ * On success the downloaded VSIX is cleaned up. On failure the VSIX is
+ * kept at `~/.archgate/archgate.vsix` so the user can install it manually.
+ */
 export async function installVscodeExtension(token: string): Promise<void> {
   const vsixPath = internalPath("archgate.vsix");
   const buffer = await downloadPluginAsset("/api/vscode", token);
@@ -303,20 +331,22 @@ export async function installVscodeExtension(token: string): Promise<void> {
   );
   await Bun.write(vsixPath, buffer);
 
+  const codeCmd = (await resolveCommand("code")) ?? "code";
+  logDebug("Installing VS Code extension via code CLI");
+  const result = await run([codeCmd, "--install-extension", vsixPath]);
+  if (result.exitCode !== 0) {
+    // Keep the VSIX on disk so the user can install it manually
+    throw new Error(
+      `code --install-extension failed (exit ${result.exitCode}). ` +
+        `The VSIX was saved to ${vsixPath} — install it manually: ` +
+        `code --install-extension "${vsixPath}"`
+    );
+  }
+
+  // Clean up only on success
   try {
-    const codeCmd = (await resolveCommand("code")) ?? "code";
-    logDebug("Installing VS Code extension via code CLI");
-    const result = await run([codeCmd, "--install-extension", vsixPath]);
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `code --install-extension failed (exit ${result.exitCode})`
-      );
-    }
-  } finally {
-    try {
-      unlinkSync(vsixPath);
-    } catch {
-      // Ignore cleanup errors
-    }
+    unlinkSync(vsixPath);
+  } catch {
+    // Ignore cleanup errors
   }
 }

--- a/tests/helpers/cursor-settings.test.ts
+++ b/tests/helpers/cursor-settings.test.ts
@@ -1,26 +1,9 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import {
-  ARCHGATE_CURSOR_RULE,
-  configureCursorSettings,
-} from "../../src/helpers/cursor-settings";
-
-describe("ARCHGATE_CURSOR_RULE", () => {
-  test("references CLI commands instead of MCP tools", () => {
-    expect(ARCHGATE_CURSOR_RULE).toContain("archgate review-context");
-    expect(ARCHGATE_CURSOR_RULE).toContain("archgate check --staged");
-    expect(ARCHGATE_CURSOR_RULE).toContain("archgate adr list");
-    expect(ARCHGATE_CURSOR_RULE).not.toContain("MCP tool");
-    expect(ARCHGATE_CURSOR_RULE).not.toContain("MCP");
-  });
-
-  test("has alwaysApply frontmatter", () => {
-    expect(ARCHGATE_CURSOR_RULE).toContain("alwaysApply: true");
-  });
-});
+import { configureCursorSettings } from "../../src/helpers/cursor-settings";
 
 describe("configureCursorSettings", () => {
   let tempDir: string;
@@ -33,32 +16,20 @@ describe("configureCursorSettings", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  test("creates .cursor/rules/ dir and governance rule file", async () => {
-    const rulePath = await configureCursorSettings(tempDir);
-
-    expect(existsSync(join(tempDir, ".cursor"))).toBe(true);
-    expect(existsSync(join(tempDir, ".cursor", "rules"))).toBe(true);
-    expect(existsSync(rulePath)).toBe(true);
+  test("returns .cursor/ directory path (no files written)", async () => {
+    const result = await configureCursorSettings(tempDir);
+    expect(result).toBe(join(tempDir, ".cursor"));
   });
 
-  test("writes the governance rule file with correct content", async () => {
-    const rulePath = await configureCursorSettings(tempDir);
-
-    const content = await Bun.file(rulePath).text();
-    expect(content).toBe(ARCHGATE_CURSOR_RULE);
+  test("does not create .cursor/ directory", async () => {
+    const { existsSync } = await import("node:fs");
+    await configureCursorSettings(tempDir);
+    expect(existsSync(join(tempDir, ".cursor"))).toBe(false);
   });
 
   test("does not create mcp.json", async () => {
+    const { existsSync } = await import("node:fs");
     await configureCursorSettings(tempDir);
-
     expect(existsSync(join(tempDir, ".cursor", "mcp.json"))).toBe(false);
-  });
-
-  test("returns correct absolute path to rules file", async () => {
-    const rulePath = await configureCursorSettings(tempDir);
-
-    expect(rulePath).toBe(
-      join(tempDir, ".cursor", "rules", "archgate-governance.mdc")
-    );
   });
 });

--- a/tests/helpers/cursor-settings.test.ts
+++ b/tests/helpers/cursor-settings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -16,20 +16,18 @@ describe("configureCursorSettings", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  test("returns .cursor/ directory path (no files written)", async () => {
-    const result = await configureCursorSettings(tempDir);
+  test("returns .cursor/ directory path (no files written)", () => {
+    const result = configureCursorSettings(tempDir);
     expect(result).toBe(join(tempDir, ".cursor"));
   });
 
-  test("does not create .cursor/ directory", async () => {
-    const { existsSync } = await import("node:fs");
-    await configureCursorSettings(tempDir);
+  test("does not create .cursor/ directory", () => {
+    configureCursorSettings(tempDir);
     expect(existsSync(join(tempDir, ".cursor"))).toBe(false);
   });
 
-  test("does not create mcp.json", async () => {
-    const { existsSync } = await import("node:fs");
-    await configureCursorSettings(tempDir);
+  test("does not create mcp.json", () => {
+    configureCursorSettings(tempDir);
     expect(existsSync(join(tempDir, ".cursor", "mcp.json"))).toBe(false);
   });
 });

--- a/tests/helpers/init-project.test.ts
+++ b/tests/helpers/init-project.test.ts
@@ -67,19 +67,11 @@ describe("initProject", () => {
     );
   });
 
-  test("configures Cursor settings when editor is cursor", async () => {
+  test("configures Cursor settings when editor is cursor (no project files)", async () => {
     const result = await initProject(tempDir, { editor: "cursor" });
 
-    // Cursor rule should exist
-    const rulePath = join(
-      tempDir,
-      ".cursor",
-      "rules",
-      "archgate-governance.mdc"
-    );
-    expect(existsSync(rulePath)).toBe(true);
-
-    // MCP config should NOT exist (MCP removed)
+    // Cursor plugin is embedded in the VSIX — no project-level files written
+    expect(existsSync(join(tempDir, ".cursor"))).toBe(false);
     expect(existsSync(join(tempDir, ".cursor", "mcp.json"))).toBe(false);
 
     // Claude settings should NOT exist
@@ -87,8 +79,8 @@ describe("initProject", () => {
       false
     );
 
-    // Result should point to cursor rule file
-    expect(result.editorSettingsPath).toBe(rulePath);
+    // Result should point to .cursor/ directory
+    expect(result.editorSettingsPath).toBe(join(tempDir, ".cursor"));
   });
 
   test("skips example ADR when ADRs already exist", async () => {

--- a/tests/integration/init.test.ts
+++ b/tests/integration/init.test.ts
@@ -53,7 +53,7 @@ describe("init integration", () => {
     );
   });
 
-  test("init with --editor cursor creates cursor rules directory and file", async () => {
+  test("init with --editor cursor does not create project-level files", async () => {
     const result = await runCli(
       ["init", "--editor", "cursor"],
       tempDir,
@@ -62,10 +62,11 @@ describe("init integration", () => {
 
     expect(result.exitCode).toBe(0);
 
-    expect(existsSync(join(tempDir, ".cursor", "rules"))).toBe(true);
+    // Cursor plugin is embedded in the VSIX — no .cursor/ files written
+    expect(existsSync(join(tempDir, ".cursor", "rules"))).toBe(false);
     expect(
       existsSync(join(tempDir, ".cursor", "rules", "archgate-governance.mdc"))
-    ).toBe(true);
+    ).toBe(false);
   });
 
   test("init with --editor copilot creates copilot directory", async () => {


### PR DESCRIPTION
## Summary

- Removes `.cursor/rules/archgate-governance.mdc` project-level file creation — the Cursor plugin (skills, agents, governance rule) is now embedded inside the VS Code extension (.vsix) and registered at runtime via `vscode.cursor.plugins.registerPath()`
- Updates manual fallback instructions to direct users to install the VSIX via Cursor's Command Palette instead of the Team Marketplace
- Updates `doctor` integration detection to use cursor CLI availability instead of checking for a project-level `.mdc` file
- Updates all tests to reflect the new behavior

## Test plan

- [ ] `bun test tests/helpers/cursor-settings.test.ts` passes (3/3)
- [ ] `bun test tests/helpers/init-project.test.ts` passes (15/15)
- [ ] `bun test tests/integration/init.test.ts --test-name-pattern cursor` passes
- [ ] `bun test tests/helpers/` passes (319/319)
- [ ] `archgate init --editor cursor` does NOT create `.cursor/rules/archgate-governance.mdc`
- [ ] `archgate plugin install --editor cursor` with cursor CLI installs VSIX and prints success
- [ ] `archgate plugin install --editor cursor` without cursor CLI shows VSIX install instructions
- [ ] `archgate doctor` shows Cursor integration status based on CLI availability