### PR TITLE
docs: add privacy policy, fix data regions, and add DCO sign-off to CI

### DIFF
--- a/.github/workflows/update-llms.yaml
+++ b/.github/workflows/update-llms.yaml
@@ -47,4 +47,5 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: "docs: regenerate llms-full.txt"
+          commit_options: "--signoff"
           file_pattern: docs/public/llms-full.txt

--- a/.github/workflows/update-lock.yaml
+++ b/.github/workflows/update-lock.yaml
@@ -42,3 +42,7 @@ jobs:
         run: bun install --lockfile-only
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
+        with:
+          commit_message: "chore: update bun.lock"
+          commit_options: "--signoff"
+          file_pattern: bun.lock

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -254,6 +254,7 @@ export default defineConfig({
             { label: "Rule API", slug: "reference/rule-api" },
             { label: "ADR Schema", slug: "reference/adr-schema" },
             { label: "Telemetry", slug: "reference/telemetry" },
+            { label: "Privacy Policy", slug: "reference/privacy-policy" },
           ],
         },
         {

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -3991,6 +3991,44 @@ Archgate upgraded to 0.4.0 successfully.
 
 ---
 
+## Reference: Privacy Policy
+
+Source: https://cli.archgate.dev/reference/privacy-policy/
+
+For the full Archgate Privacy Policy, please visit:
+
+**[archgate.dev/privacy-policy](https://archgate.dev/privacy-policy)**
+
+The sections below summarize the most relevant points for CLI users. The canonical policy on the website is the legally binding version.
+
+## Summary for CLI users
+
+### What the CLI collects
+
+Archgate collects **anonymous usage analytics** (via PostHog) and **crash reports** (via Sentry) to improve the tool. No personal information, source code, file content, or AI prompts are ever collected by the CLI itself. See the [Telemetry](/reference/telemetry/) page for a detailed breakdown of every data point.
+
+### Archgate Plugins Service
+
+When you sign up via `archgate login`, the **Plugins Service** (`plugins.archgate.dev`) collects personal information: your **email address**, **GitHub username**, **editor choice**, and a **use case description**. This data is used to provision your account and send a welcome email. Authentication tokens are stored as SHA-256 hashes on our servers; on your machine, credentials are kept in your OS credential manager (never as plain-text files). See the [full privacy policy](https://archgate.dev/privacy-policy) for complete details.
+
+### How to opt out
+
+```bash
+# Environment variable (immediate, per-session or in shell profile)
+export ARCHGATE_TELEMETRY=0
+
+# Or persistently via the CLI
+archgate telemetry disable
+```
+
+Note: telemetry opt-out disables CLI analytics and crash reporting. It does not affect the Plugins Service account data, which is required for plugin access. To delete your account data, contact [privacy@archgate.dev](mailto:privacy@archgate.dev).
+
+### What the docs site collects
+
+This documentation site (`cli.archgate.dev`) uses [Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/), a privacy-first analytics service. Cloudflare Web Analytics does not use cookies, does not track individual visitors, and does not collect personal information. It provides aggregate page-view and performance metrics only.
+
+---
+
 ## Reference: Rule API
 
 Source: https://cli.archgate.dev/reference/rule-api/
@@ -4418,8 +4456,8 @@ The environment variable takes precedence over the CLI setting. If `ARCHGATE_TEL
 
 ## Where data is stored
 
-- **Analytics**: PostHog Cloud (US region). Data retained per PostHog's standard retention policy.
-- **Error tracking**: Sentry Cloud (US region). Error events retained for 90 days.
+- **Analytics**: PostHog Cloud (EU region). Data retained per PostHog's standard retention policy.
+- **Error tracking**: Sentry Cloud (EU region). Error events retained for 90 days.
 - **Local config**: `~/.archgate/config.json` stores your telemetry preference and anonymous install ID.
 
 ## Open source

--- a/docs/src/content/docs/pt-br/reference/privacy-policy.mdx
+++ b/docs/src/content/docs/pt-br/reference/privacy-policy.mdx
@@ -13,7 +13,7 @@ As seções abaixo resumem os pontos mais relevantes para usuários da CLI. A po
 
 ### O que a CLI coleta
 
-O Archgate coleta **análises de uso anônimas** (via PostHog) e **relatórios de falha** (via Sentry) para melhorar a ferramenta. Nenhuma informação pessoal, código-fonte, conteúdo de arquivo ou prompts de IA são coletados pela CLI em si. Consulte a página de [Telemetria](/pt-br/reference/telemetry/) para um detalhamento completo de cada ponto de dados.
+O Archgate coleta **análises de uso anônimas** (via PostHog) e **relatórios de falha** (via Sentry) para melhorar a ferramenta. Nenhuma informação pessoal, código-fonte, conteúdo de arquivo ou prompts de IA são coletados pela CLI em si. Consulte a página de [Telemetria](/reference/telemetry/) para um detalhamento completo de cada ponto de dados.
 
 ### Serviço de Plugins do Archgate
 

--- a/docs/src/content/docs/pt-br/reference/privacy-policy.mdx
+++ b/docs/src/content/docs/pt-br/reference/privacy-policy.mdx
@@ -1,0 +1,36 @@
+---
+title: Política de Privacidade
+description: Como o Archgate trata seus dados, o que coletamos e seus direitos.
+---
+
+Para a Política de Privacidade completa do Archgate, acesse:
+
+**[archgate.dev/privacy-policy](https://archgate.dev/privacy-policy)**
+
+As seções abaixo resumem os pontos mais relevantes para usuários da CLI. A política canônica no site é a versão juridicamente vinculante.
+
+## Resumo para usuários da CLI
+
+### O que a CLI coleta
+
+O Archgate coleta **análises de uso anônimas** (via PostHog) e **relatórios de falha** (via Sentry) para melhorar a ferramenta. Nenhuma informação pessoal, código-fonte, conteúdo de arquivo ou prompts de IA são coletados pela CLI em si. Consulte a página de [Telemetria](/pt-br/reference/telemetry/) para um detalhamento completo de cada ponto de dados.
+
+### Serviço de Plugins do Archgate
+
+Quando você se cadastra via `archgate login`, o **Serviço de Plugins** (`plugins.archgate.dev`) coleta informações pessoais: seu **endereço de email**, **nome de usuário GitHub**, **escolha do editor** e uma **descrição do caso de uso**. Esses dados são usados para provisionar sua conta e enviar um email de boas-vindas. Os tokens de autenticação são armazenados como hashes SHA-256 em nossos servidores; na sua máquina, as credenciais são mantidas no gerenciador de credenciais do seu sistema operacional (nunca como arquivos de texto simples). Consulte a [política de privacidade completa](https://archgate.dev/privacy-policy) para detalhes completos.
+
+### Como desativar
+
+```bash
+# Variável de ambiente (imediato, por sessão ou no perfil do shell)
+export ARCHGATE_TELEMETRY=0
+
+# Ou persistentemente via CLI
+archgate telemetry disable
+```
+
+Nota: a desativação da telemetria desabilita as análises da CLI e os relatórios de falha. Ela não afeta os dados de conta do Serviço de Plugins, que são necessários para acesso aos plugins. Para excluir os dados da sua conta, entre em contato com [privacy@archgate.dev](mailto:privacy@archgate.dev).
+
+### O que o site de documentação coleta
+
+Este site de documentação (`cli.archgate.dev`) usa [Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/), um serviço de análise que prioriza a privacidade. O Cloudflare Web Analytics não usa cookies, não rastreia visitantes individuais e não coleta informações pessoais. Ele fornece apenas métricas agregadas de visualização de página e desempenho.

--- a/docs/src/content/docs/pt-br/reference/telemetry.mdx
+++ b/docs/src/content/docs/pt-br/reference/telemetry.mdx
@@ -114,8 +114,8 @@ A variável de ambiente tem prioridade sobre a configuração da CLI. Se `ARCHGA
 
 ## Onde os dados são armazenados
 
-- **Análise**: PostHog Cloud (região dos EUA). Dados retidos conforme a política de retenção padrão do PostHog.
-- **Rastreamento de erros**: Sentry Cloud (região dos EUA). Eventos de erro retidos por 90 dias.
+- **Análise**: PostHog Cloud (região da UE). Dados retidos conforme a política de retenção padrão do PostHog.
+- **Rastreamento de erros**: Sentry Cloud (região da UE). Eventos de erro retidos por 90 dias.
 - **Configuração local**: `~/.archgate/config.json` armazena sua preferência de telemetria e o ID de instalação anônimo.
 
 ## Código aberto

--- a/docs/src/content/docs/reference/privacy-policy.mdx
+++ b/docs/src/content/docs/reference/privacy-policy.mdx
@@ -1,0 +1,36 @@
+---
+title: Privacy Policy
+description: How Archgate handles your data, what we collect, and your rights.
+---
+
+For the full Archgate Privacy Policy, please visit:
+
+**[archgate.dev/privacy-policy](https://archgate.dev/privacy-policy)**
+
+The sections below summarize the most relevant points for CLI users. The canonical policy on the website is the legally binding version.
+
+## Summary for CLI users
+
+### What the CLI collects
+
+Archgate collects **anonymous usage analytics** (via PostHog) and **crash reports** (via Sentry) to improve the tool. No personal information, source code, file content, or AI prompts are ever collected by the CLI itself. See the [Telemetry](/reference/telemetry/) page for a detailed breakdown of every data point.
+
+### Archgate Plugins Service
+
+When you sign up via `archgate login`, the **Plugins Service** (`plugins.archgate.dev`) collects personal information: your **email address**, **GitHub username**, **editor choice**, and a **use case description**. This data is used to provision your account and send a welcome email. Authentication tokens are stored as SHA-256 hashes on our servers; on your machine, credentials are kept in your OS credential manager (never as plain-text files). See the [full privacy policy](https://archgate.dev/privacy-policy) for complete details.
+
+### How to opt out
+
+```bash
+# Environment variable (immediate, per-session or in shell profile)
+export ARCHGATE_TELEMETRY=0
+
+# Or persistently via the CLI
+archgate telemetry disable
+```
+
+Note: telemetry opt-out disables CLI analytics and crash reporting. It does not affect the Plugins Service account data, which is required for plugin access. To delete your account data, contact [privacy@archgate.dev](mailto:privacy@archgate.dev).
+
+### What the docs site collects
+
+This documentation site (`cli.archgate.dev`) uses [Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/), a privacy-first analytics service. Cloudflare Web Analytics does not use cookies, does not track individual visitors, and does not collect personal information. It provides aggregate page-view and performance metrics only.

--- a/docs/src/content/docs/reference/telemetry.mdx
+++ b/docs/src/content/docs/reference/telemetry.mdx
@@ -114,8 +114,8 @@ The environment variable takes precedence over the CLI setting. If `ARCHGATE_TEL
 
 ## Where data is stored
 
-- **Analytics**: PostHog Cloud (US region). Data retained per PostHog's standard retention policy.
-- **Error tracking**: Sentry Cloud (US region). Error events retained for 90 days.
+- **Analytics**: PostHog Cloud (EU region). Data retained per PostHog's standard retention policy.
+- **Error tracking**: Sentry Cloud (EU region). Error events retained for 90 days.
 - **Local config**: `~/.archgate/config.json` stores your telemetry preference and anonymous install ID.
 
 ## Open source


### PR DESCRIPTION
## Summary

- Adds a **Privacy Policy** summary page to the CLI docs (EN + PT-BR) linking to the canonical policy at `archgate.dev/privacy-policy`
- Corrects PostHog and Sentry data hosting regions from **US → EU** on the Telemetry page
- Fixes automated commit workflows (`update-llms`, `update-lock`) to include **DCO sign-off** and conventional commit messages

## Changes

| File | Change |
|------|--------|
| `docs/src/content/docs/reference/privacy-policy.mdx` | New EN privacy policy summary page |
| `docs/src/content/docs/pt-br/reference/privacy-policy.mdx` | New PT-BR privacy policy summary page |
| `docs/src/content/docs/reference/telemetry.mdx` | PostHog and Sentry regions: US → EU |
| `docs/src/content/docs/pt-br/reference/telemetry.mdx` | PostHog and Sentry regions: EUA → UE |
| `docs/astro.config.mjs` | Add "Privacy Policy" to Reference sidebar |
| `.github/workflows/update-llms.yaml` | Add `commit_options: "--signoff"` |
| `.github/workflows/update-lock.yaml` | Add `commit_message`, `commit_options: "--signoff"`, and `file_pattern` |

## Context

### Privacy Policy

The page summarizes CLI telemetry (PostHog + Sentry), the Plugins Service account data (email, GitHub username, editor choice, use case), telemetry opt-out instructions, and docs site analytics (Cloudflare Web Analytics). It links to the canonical policy on the website repo (archgate/website#33).

### Data Regions

PostHog and Sentry are both hosted in the EU, not the US as previously documented.

### DCO Sign-off

Both `update-llms.yaml` and `update-lock.yaml` use `stefanzweifel/git-auto-commit-action` to push commits to PR branches. These commits were missing the `Signed-off-by` trailer, causing DCO check failures on every PR they touched. Additionally, `update-lock.yaml` was missing a `commit_message` (defaulting to "Apply automatic changes" which fails commitlint) and a `file_pattern` (committing all changes instead of just `bun.lock`).

## Test plan

- [ ] `bun run validate` passes
- [ ] Privacy Policy page renders at `/reference/privacy-policy`
- [ ] PT-BR version renders at `/pt-br/reference/privacy-policy`
- [ ] Sidebar shows "Privacy Policy" under Reference section
- [ ] Telemetry page shows EU (not US) for PostHog and Sentry regions
- [ ] `update-llms` workflow commits include `Signed-off-by` trailer
- [ ] `update-lock` workflow commits include `Signed-off-by` trailer and use conventional commit message