### PR TITLE
ci: add Codecov coverage reporting

### DIFF
--- a/.github/workflows/code-pull-request.yml
+++ b/.github/workflows/code-pull-request.yml
@@ -1,6 +1,9 @@
 name: Validate
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches:

--- a/.github/workflows/code-pull-request.yml
+++ b/.github/workflows/code-pull-request.yml
@@ -64,6 +64,14 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info
           fail_ci_if_error: false
+      - name: Upload test results to Codecov
+        if: always() && steps.validate.outcome != 'skipped'
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/junit.xml
+          report-type: test_results
+          fail_ci_if_error: false
       - name: Save Bun Cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         if: steps.validate.outcome == 'success' && steps.restore-bun-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/code-pull-request.yml
+++ b/.github/workflows/code-pull-request.yml
@@ -1,9 +1,6 @@
 name: Validate
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches:

--- a/.github/workflows/code-pull-request.yml
+++ b/.github/workflows/code-pull-request.yml
@@ -56,7 +56,14 @@ jobs:
           }
       - name: Validate
         id: validate
-        run: bun run validate
+        run: bun run validate:coverage
+      - name: Upload coverage to Codecov
+        if: always() && steps.validate.outcome == 'success'
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
+          fail_ci_if_error: false
       - name: Save Bun Cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         if: steps.validate.outcome == 'success' && steps.restore-bun-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,22 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Validate
         id: validate
-        run: bun run validate
+        run: bun run validate:coverage
+      - name: Upload coverage to Codecov
+        if: always() && steps.validate.outcome == 'success'
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
+          fail_ci_if_error: false
+      - name: Upload test results to Codecov
+        if: always() && steps.validate.outcome != 'skipped'
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/junit.xml
+          report-type: test_results
+          fail_ci_if_error: false
       - name: Ensure main is up-to-date before release
         run: git pull --rebase origin main
       - name: Release

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -6,3 +6,5 @@ saveTextLockfile = true
 
 [test]
 preload = ["./tests/preload.ts"]
+coverageReporter = ["lcov", "text"]
+coverageDir = "coverage"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+
+comment:
+  layout: "header, diff, flags, components"
+  behavior: default
+  require_changes: true
+  require_base: false
+  require_head: true
+
+ignore:
+  - "docs/**"
+  - "scripts/**"
+  - "tests/**"
+  - ".archgate/**"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint": "oxlint --deny-warnings .",
     "postinstall": "node scripts/postinstall.cjs",
     "test": "bun test --timeout 60000",
-    "test:coverage": "bun test --timeout 60000 --coverage",
+    "test:coverage": "bun test --timeout 60000 --coverage --reporter=junit --reporter-outfile=coverage/junit.xml",
     "test:watch": "bun test --watch --timeout 60000",
     "typecheck": "tsc --build",
     "validate": "bun run lint && bun run typecheck && bun run format:check && bun run test && bun run check && bun run build:check",

--- a/package.json
+++ b/package.json
@@ -50,9 +50,11 @@
     "lint": "oxlint --deny-warnings .",
     "postinstall": "node scripts/postinstall.cjs",
     "test": "bun test --timeout 60000",
+    "test:coverage": "bun test --timeout 60000 --coverage",
     "test:watch": "bun test --watch --timeout 60000",
     "typecheck": "tsc --build",
-    "validate": "bun run lint && bun run typecheck && bun run format:check && bun run test && bun run check && bun run build:check"
+    "validate": "bun run lint && bun run typecheck && bun run format:check && bun run test && bun run check && bun run build:check",
+    "validate:coverage": "bun run lint && bun run typecheck && bun run format:check && bun run test:coverage && bun run check && bun run build:check"
   },
   "devDependencies": {
     "@commander-js/extra-typings": "14.0.0",


### PR DESCRIPTION
## Summary

- Generate lcov coverage reports using Bun's built-in `--coverage` flag (zero new dependencies)
- Upload reports to Codecov via SHA-pinned `codecov/codecov-action@v6.0.0` on every PR run
- Add `test:coverage` and `validate:coverage` scripts so local `bun run validate` stays fast (no coverage overhead)
- Configure Codecov thresholds: project target auto (1% threshold), patch target 80%

## Test plan

- [x] `bun run validate` passes locally (725 tests, 23/23 ADR rules)
- [x] `bun run test:coverage` generates `coverage/lcov.info` successfully
- [ ] CI workflow runs `validate:coverage` and uploads report to Codecov
- [ ] Codecov bot posts coverage summary on this PR