### PR TITLE
fix(ci): remove proto 0.56.3 pin from Windows smoke test

### DIFF
--- a/.github/workflows/smoke-test-windows.yml
+++ b/.github/workflows/smoke-test-windows.yml
@@ -23,11 +23,6 @@ jobs:
       - uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095 # v0
         with:
           auto-install: true
-          # Pin proto to 0.56.3 — v0.56.4 has a regression in starbase_archive
-          # 0.13.0 that prevents Node 24 from extracting on Windows Server 2025.
-          # Remove this pin once proto 0.57+ ships with the fix.
-          # See: https://github.com/moonrepo/proto/issues/1006
-          proto-version: "0.56.3"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Removes the proto 0.56.3 pin added as a workaround for [moonrepo/proto#1006](https://github.com/moonrepo/proto/issues/1006)
- Proto 0.57.0 shipped with updated starbase dependencies (`starbase_archive` 0.13.1, `starbase_utils` 0.13.2) — testing whether the Node 24 install regression on Windows Server 2025 is resolved

## Test plan

- [ ] Windows smoke test CI job passes (Node 24 installs and runs on `windows-latest`)
- [ ] If it fails, the CI logs give us the evidence to continue debugging upstream