### PR TITLE
fix(ci): revert SLSA reusable workflow to tag pin

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -166,7 +166,7 @@ jobs:
     # generate-builder.sh extracts the version from the ref to download the builder
     # binary from a GitHub release and rejects non-tag refs. See CI-001 exception
     # and slsa-framework/slsa-github-generator#150.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.combine-hashes.outputs.digests }}"
       upload-assets: true


### PR DESCRIPTION
## Summary

- Reverts the SLSA generator reference from SHA pin (`@f7dd8c54c...`) back to tag pin (`@v2.1.0`)
- Renovate PR #284 re-pinned it to SHA, breaking provenance on the v0.37.0 release ([run 26056480895](https://github.com/archgate/cli/actions/runs/26056480895/job/76606717168))
- A Renovate exclusion rule has been added in [archgate/renovate-config#10](https://github.com/archgate/renovate-config/pull/10) to prevent this from recurring

## Context

The SLSA generator's `generate-builder.sh` reads the workflow ref to download the prebuilt builder binary. It rejects non-tag refs (`Invalid ref: Expected ref of the form refs/tags/vX.Y.Z`). This is the same fix as #250.

Upstream issue: [slsa-framework/slsa-github-generator#150](https://github.com/slsa-framework/slsa-github-generator/issues/150)

## Test plan

- [ ] Merge and re-run the release workflow for v0.37.0 via `workflow_dispatch` — SLSA provenance should pass