### PR TITLE
ci: add PostHog release annotations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,29 @@ jobs:
           branch: release
         env:
           NPM_CONFIG_PROVENANCE: "true"
+      - name: Annotate release in PostHog
+        if: success()
+        continue-on-error: true
+        env:
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ vars.POSTHOG_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${POSTHOG_PERSONAL_API_KEY:-}" ] || [ -z "${POSTHOG_PROJECT_ID:-}" ]; then
+            echo "::notice::Skipping PostHog annotation — POSTHOG_PERSONAL_API_KEY or POSTHOG_PROJECT_ID not configured"
+            exit 0
+          fi
+          version=$(jq -r .version package.json)
+          curl -fsS -X POST "https://eu.posthog.com/api/projects/${POSTHOG_PROJECT_ID}/annotations/" \
+            -H "Authorization: Bearer ${POSTHOG_PERSONAL_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"content\": \"v${version}\",
+              \"date_marker\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",
+              \"scope\": \"project\",
+              \"creation_type\": \"GIT\"
+            }"
+          echo "::notice::PostHog annotation created for v${version}"
       - name: Save Bun Cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         if: steps.validate.outcome == 'success' && steps.restore-bun-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

- Adds a step to the release workflow that creates a PostHog annotation on each release, so version markers (e.g. `v0.38.0`) appear as vertical lines on all timeline graphs
- Uses the PostHog Annotations API (`POST /api/projects/{id}/annotations/`) with `creation_type: "GIT"` for automated tagging
- `continue-on-error: true` ensures annotation failures never block a release
- Gracefully skips when secrets are not configured (safe for forks)

## Setup required

Two new GitHub settings must be configured before annotations appear:

1. **Secret `POSTHOG_PERSONAL_API_KEY`** — a PostHog personal API key with annotations write scope (Settings → Personal API Keys)
2. **Variable `POSTHOG_PROJECT_ID`** — the numeric project ID from the PostHog dashboard URL

## Test plan

- [ ] Verify `POSTHOG_PERSONAL_API_KEY` and `POSTHOG_PROJECT_ID` are set in the repo
- [ ] Trigger a release and confirm the annotation appears in PostHog timeline views
- [ ] Verify the step logs `::notice::PostHog annotation created for v<version>`
- [ ] Confirm the release succeeds even if PostHog API is unreachable (continue-on-error)