### PR TITLE
fix(ci): detect workflow changes that affect shim tests

### DIFF
--- a/.github/workflows/code-pull-request.yml
+++ b/.github/workflows/code-pull-request.yml
@@ -86,10 +86,15 @@ jobs:
       - name: Check for shim changes
         id: changes
         run: |
+          # Detect changes to shim source code AND workflow files that configure
+          # shim test/publish infrastructure (e.g., action version bumps, runtime
+          # version changes). Without checking workflow files, a Renovate PR that
+          # bumps Ruby 3.3→3.4 in the shim-tests job would skip tests entirely.
+          PATHS="shims/ .github/workflows/publish-shims.yml .github/workflows/code-pull-request.yml"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- shims/ || true)
+            CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- $PATHS || true)
           else
-            CHANGED=$(git diff --name-only HEAD~1 -- shims/ || true)
+            CHANGED=$(git diff --name-only HEAD~1 -- $PATHS || true)
           fi
           if [ -n "$CHANGED" ]; then
             echo "shims_changed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- The `shim-changes` detection job only checked `git diff ... -- shims/`, missing changes to the workflow files that configure shim test infrastructure
- Renovate PR #358 bumps Ruby 3.3→3.4.9 in both `code-pull-request.yml` and `publish-shims.yml`, but because those files are under `.github/workflows/` (not `shims/`), the detector outputs `shims_changed=false` and **all shim tests are skipped**
- Extended the diff paths to also include `.github/workflows/publish-shims.yml` and `.github/workflows/code-pull-request.yml` so shim tests run when their CI infrastructure changes

## Test plan

- [ ] Verify this PR's own CI run triggers the shim-tests job (since `code-pull-request.yml` itself changed)
- [ ] After merging, verify Renovate PR #358 re-runs CI and the shim-tests job executes