### PR TITLE
fix(shims): gitignore Bundler artifacts that break rubygem publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ shims/go/cmd/archgate/archgate
 shims/go/cmd/archgate/archgate.exe
 shims/rubygem/pkg/
 shims/rubygem/*.gem
+shims/rubygem/Gemfile.lock
+shims/rubygem/.bundle/
+shims/rubygem/vendor/
 shims/pypi/**/__pycache__/
 shims/pypi/.pytest_cache/
 


### PR DESCRIPTION
## Summary

- Adds `.gitignore` entries for `Gemfile.lock`, `.bundle/`, and `vendor/` under `shims/rubygem/`
- `ruby/setup-ruby` with `bundler-cache: true` generates these as untracked files during CI
- Bundler's `release:guard_clean` task (part of `rake release`) aborts when **any** untracked file exists in the repo, failing the `publish-rubygem` job

This is the third publish failure in a row for rubygem:
| Version | Error | Fix |
|---------|-------|-----|
| v0.40.0 | `Could not locate Gemfile` — wrong working dir | #368 |
| v0.41.0 | `failed to load command: rake` — Ruby 4.0 dropped default rake | #377 |
| **v0.41.1** | **`There are files that need to be committed first`** — untracked Bundler artifacts | **This PR** |

## Test plan

- [ ] Merge, create a new release tag, and verify `publish-rubygem` job passes
- [ ] Alternatively, `workflow_dispatch` the `publish-shims.yml` workflow with the `v0.41.1` tag after merging