### PR TITLE
fix(deps): resolve dependency dashboard deprecation and lookup warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Context check
         id: check
-        uses: TrigenSoftware/simple-release-action@a796225481a62b5b46b37d4481ef7fb114a6d399 # v1
+        uses: TrigenSoftware/simple-release-action@e7293dad843693d8692d443c3f21b78338048f13 # v1.1.8
         with:
           workflow: check
           github-token: ${{ steps.generate_token.outputs.token }}
@@ -112,7 +112,7 @@ jobs:
           HOOK
           chmod +x .git/hooks/prepare-commit-msg
       - name: Create or update pull request
-        uses: TrigenSoftware/simple-release-action@a796225481a62b5b46b37d4481ef7fb114a6d399 # v1
+        uses: TrigenSoftware/simple-release-action@e7293dad843693d8692d443c3f21b78338048f13 # v1.1.8
         with:
           workflow: pull-request
           github-token: ${{ steps.generate_token.outputs.token }}
@@ -156,7 +156,7 @@ jobs:
       - name: Ensure main is up-to-date before release
         run: git pull --rebase origin main
       - name: Release
-        uses: TrigenSoftware/simple-release-action@a796225481a62b5b46b37d4481ef7fb114a6d399 # v1
+        uses: TrigenSoftware/simple-release-action@e7293dad843693d8692d443c3f21b78338048f13 # v1.1.8
         with:
           workflow: release
           github-token: ${{ steps.generate_token.outputs.token }}

--- a/shims/nuget/tests/Archgate.Tool.Tests/Archgate.Tool.Tests.csproj
+++ b/shims/nuget/tests/Archgate.Tool.Tests/Archgate.Tool.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Archgate.Tool.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -10,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.*">
+    <PackageReference Include="xunit.v3" Version="3.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Addresses the deprecation and warning flagged in the [Dependency Dashboard](https://github.com/archgate/cli/issues/107):

- **xunit deprecation**: Migrate NuGet shim tests from deprecated `xunit` v2 to `xunit.v3` v3, update `xunit.runner.visualstudio` to v3, and add `<OutputType>Exe</OutputType>` (required by xUnit v3 test projects). No test source changes needed — `[Fact]`/`[Theory]`/`Assert.*` APIs are backward compatible.
- **Renovate lookup failure**: Update `TrigenSoftware/simple-release-action` from an unresolvable SHA (tagged as generic `# v1`) to the latest `v1.1.8` release (`e7293dad`). The old SHA didn't match any known tag, preventing Renovate from determining update digests.

## Test plan

- [ ] CI "Validate Shims" job passes for the `nuget` matrix entry (`dotnet test` with xUnit v3)
- [ ] CI "Lint, Test & Check" job passes (no TS-side regressions)
- [ ] Renovate Dependency Dashboard no longer shows the `simple-release-action` lookup warning after merge

Closes #107