### PR TITLE
ci: resolve deprecation warnings and Go cache failure

### DIFF
--- a/.github/workflows/code-pull-request.yml
+++ b/.github/workflows/code-pull-request.yml
@@ -135,6 +135,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.21"
+          cache-dependency-path: shims/go/go.sum
       - name: Test Go shim
         if: matrix.shim == 'go'
         working-directory: shims/go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ permissions: {}
 
 env:
   ARCHGATE_TELEMETRY: "0"
+  # Opt into Node.js 24 for all actions — TrigenSoftware/simple-release-action
+  # still declares `using: node20` and GitHub will force Node 24 on June 16, 2026.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   check:
@@ -31,7 +34,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.GH_APP_APP_ID }}
+          client-id: ${{ secrets.GH_APP_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -78,7 +81,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.GH_APP_APP_ID }}
+          client-id: ${{ secrets.GH_APP_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -131,7 +134,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.GH_APP_APP_ID }}
+          client-id: ${{ secrets.GH_APP_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

- **`app-id` → `client-id`** — Replace deprecated `app-id` input with `client-id` in all 3 `actions/create-github-app-token` steps in `release.yml` (same secret, just the input name)
- **Node.js 24 opt-in** — Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to `release.yml` so `TrigenSoftware/simple-release-action` (stuck on `node20`) runs on Node 24 ahead of the June 16 forced migration
- **Go cache fix** — Add `cache-dependency-path: shims/go/go.sum` to `actions/setup-go` in `code-pull-request.yml` so it finds the dependency file in the shim subdirectory instead of failing with "Dependencies file is not found"

## Test plan

- [ ] Merge and verify the Release workflow runs without `app-id` deprecation warnings
- [ ] Verify the `simple-release-action` steps succeed under Node.js 24
- [ ] Verify the "Shim Tests (go)" job no longer shows a cache restore warning