### PR TITLE
docs: restore GFM table rendering in MDX pages

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,8 +1,10 @@
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
+import remarkGfm from "remark-gfm";
 
 export default defineConfig({
   site: "https://cli.archgate.dev",
+  markdown: { remarkPlugins: [remarkGfm] },
   integrations: [
     starlight({
       title: "Archgate",

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -8,6 +8,7 @@
         "@astrojs/starlight": "^0.39.0",
         "astro": "^6.0.0",
         "posthog-js": "^1.368.2",
+        "remark-gfm": "^4.0.1",
         "sharp": "^0.34.1",
       },
     },

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
     "@astrojs/starlight": "^0.39.0",
     "astro": "^6.0.0",
     "posthog-js": "^1.368.2",
+    "remark-gfm": "^4.0.1",
     "sharp": "^0.34.1"
   }
 }


### PR DESCRIPTION
## Summary

- Astro 5+/6 dropped `remark-gfm` from MDX processing by default, causing all markdown tables across the docs site to render as raw pipe-delimited text instead of proper `<table>` HTML
- Added `remark-gfm` as a direct dependency and enabled it via `markdown: { remarkPlugins: [remarkGfm] }` in `astro.config.mjs`
- Fixes broken tables on **98 MDX pages** across all 3 locales (en, pt-br, nb)

## Test plan

- [x] `bun run build` in `docs/` succeeds — both tables on `/getting-started/installation/` produce `<table>` elements in the output HTML
- [x] Verified all 3 locale variants (`/`, `/pt-br/`, `/nb/`) render 2 tables each
- [x] `bun run validate` passes (lint, typecheck, format, ADR check, knip, build)