### PR TITLE
docs: move lead copy off governance wording to linting and guardrails

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This document describes what Archgate intends to build, improve, and explicitly 
 
 ## Vision
 
-Archgate becomes the standard governance layer for AI-assisted development. ADRs are the universal format for expressing architectural decisions, and Archgate enforces them automatically — across AI tools, CI systems, and teams.
+Archgate becomes the standard linting and guardrails for AI-assisted development. ADRs are the universal format for expressing architectural decisions, and Archgate enforces them automatically — across AI tools, CI systems, and teams.
 
 ## What's Done (Phases 0–2.5)
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -4020,7 +4020,7 @@ archgate check --help
 | Command                                          | Description                                           |
 | ------------------------------------------------ | ----------------------------------------------------- |
 | [`archgate login`](./login/)                     | Authenticate with GitHub                              |
-| [`archgate init`](./init/)                       | Initialize Archgate governance                        |
+| [`archgate init`](./init/)                       | Set up linting and rules enforcement                  |
 | [`archgate plugin`](./plugin/)                   | Manage editor plugins                                 |
 | [`archgate check`](./check/)                     | Run ADR compliance checks                             |
 | [`archgate adr`](./adr/)                         | Create, list, show, and update ADRs                   |
@@ -4036,7 +4036,7 @@ archgate check --help
 
 Source: https://cli.archgate.dev/reference/cli/init/
 
-Initialize Archgate governance in the current project.
+Set up Archgate linting and rules enforcement in the current project.
 
 ```bash
 archgate init [options]

--- a/docs/src/content/docs/concepts/domains.mdx
+++ b/docs/src/content/docs/concepts/domains.mdx
@@ -1,6 +1,6 @@
 ---
 title: Domains
-description: Organize Architecture Decision Records by domain in Archgate. Group ADRs by architecture, testing, security, or any custom category for targeted governance.
+description: Organize Architecture Decision Records by domain in Archgate. Group ADRs by architecture, testing, security, or any custom category to scope and enforce rules.
 ---
 
 Domains are categories that group related ADRs together. Every ADR belongs to exactly one domain, and the domain determines the prefix used in the ADR's identifier.

--- a/docs/src/content/docs/examples/common-rule-patterns.mdx
+++ b/docs/src/content/docs/examples/common-rule-patterns.mdx
@@ -1,6 +1,6 @@
 ---
 title: Common Rule Patterns
-description: "Ready-to-use Archgate rule patterns for common governance needs: dependency management, import restrictions, file structure, code quality, database schema, and architecture boundaries."
+description: "Copy-paste rule patterns for enforcing common checks: dependency management, import restrictions, file structure, code quality, database schema, and architecture boundaries."
 sidebar:
   order: 0
 ---

--- a/docs/src/content/docs/nb/concepts/domains.mdx
+++ b/docs/src/content/docs/nb/concepts/domains.mdx
@@ -1,6 +1,6 @@
 ---
 title: Domener
-description: Organiser Architecture Decision Records etter domene i Archgate. Grupper ADR-er etter arkitektur, testing, sikkerhet eller enhver egendefinert kategori for målrettet styring.
+description: Organiser Architecture Decision Records etter domene i Archgate. Grupper ADR-er etter arkitektur, testing, sikkerhet eller enhver egendefinert kategori for å avgrense og håndheve regler.
 ---
 
 Domener er kategorier som grupperer relaterte ADR-er. Hver ADR tilhører nøyaktig ett domene, og domenet bestemmer prefikset som brukes i ADR-ens identifikator.

--- a/docs/src/content/docs/nb/examples/common-rule-patterns.mdx
+++ b/docs/src/content/docs/nb/examples/common-rule-patterns.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vanlige regelmønstre
-description: "Bruksklare Archgate-regelmønstre for vanlige styringsbehov: avhengighetsstyring, importrestriksjoner, filstruktur, kodekvalitet, databaseskjema og arkitekturgrenser."
+description: "Kopierbare regelmønstre som håndhever vanlige sjekker: avhengighetsstyring, importrestriksjoner, filstruktur, kodekvalitet, databaseskjema og arkitekturgrenser."
 sidebar:
   order: 0
 ---

--- a/docs/src/content/docs/nb/reference/cli/index.mdx
+++ b/docs/src/content/docs/nb/reference/cli/index.mdx
@@ -22,7 +22,7 @@ archgate check --help
 | Kommando                                         | Beskrivelse                                                     |
 | ------------------------------------------------ | --------------------------------------------------------------- |
 | [`archgate login`](./login/)                     | Autentiser med GitHub                                           |
-| [`archgate init`](./init/)                       | Initialiser Archgate-styring                                    |
+| [`archgate init`](./init/)                       | Sett opp linting og regelhåndhevelse                            |
 | [`archgate plugin`](./plugin/)                   | Administrer editor-plugins                                      |
 | [`archgate check`](./check/)                     | Kjør ADR-samsvarskontroller                                     |
 | [`archgate adr`](./adr/)                         | Opprett, list, vis og oppdater ADR-er                           |

--- a/docs/src/content/docs/nb/reference/cli/init.mdx
+++ b/docs/src/content/docs/nb/reference/cli/init.mdx
@@ -1,9 +1,9 @@
 ---
 title: archgate init
-description: "Initialiser Archgate-styring i det gjeldende prosjektet."
+description: "Sett opp Archgate-linting og regelhåndhevelse i det gjeldende prosjektet."
 ---
 
-Initialiser Archgate-styring i det gjeldende prosjektet.
+Sett opp Archgate-linting og regelhåndhevelse i det gjeldende prosjektet.
 
 ```bash
 archgate init [options]

--- a/docs/src/content/docs/pt-br/concepts/domains.mdx
+++ b/docs/src/content/docs/pt-br/concepts/domains.mdx
@@ -1,6 +1,6 @@
 ---
 title: Domínios
-description: Organize Architecture Decision Records por domínio no Archgate. Agrupe ADRs por arquitetura, testes, segurança ou qualquer categoria para governança direcionada.
+description: Organize Architecture Decision Records por domínio no Archgate. Agrupe ADRs por arquitetura, testes, segurança ou qualquer categoria para delimitar e aplicar regras.
 ---
 
 Domínios são categorias que agrupam ADRs relacionados. Cada ADR pertence a exatamente um domínio, e o domínio determina o prefixo usado no identificador do ADR.

--- a/docs/src/content/docs/pt-br/examples/common-rule-patterns.mdx
+++ b/docs/src/content/docs/pt-br/examples/common-rule-patterns.mdx
@@ -1,6 +1,6 @@
 ---
 title: Padrões Comuns de Regras
-description: "Padrões de regras Archgate prontos para uso, organizados por categoria: gerenciamento de dependências, restrições de import, estrutura de arquivos, qualidade de código, esquema de banco de dados e limites de arquitetura."
+description: "Padrões de regra prontos para copiar que aplicam checagens comuns: gerenciamento de dependências, restrições de import, estrutura de arquivos, qualidade de código, esquema de banco de dados e limites de arquitetura."
 sidebar:
   order: 0
 ---

--- a/docs/src/content/docs/pt-br/reference/cli/index.mdx
+++ b/docs/src/content/docs/pt-br/reference/cli/index.mdx
@@ -22,7 +22,7 @@ archgate check --help
 | Comando                                          | Descrição                                                |
 | ------------------------------------------------ | -------------------------------------------------------- |
 | [`archgate login`](./login/)                     | Autenticar com o GitHub                                  |
-| [`archgate init`](./init/)                       | Inicializar a governança do Archgate                     |
+| [`archgate init`](./init/)                       | Configurar linting e aplicação de regras                 |
 | [`archgate plugin`](./plugin/)                   | Gerenciar plugins de editor                              |
 | [`archgate check`](./check/)                     | Executar verificações de conformidade com ADRs           |
 | [`archgate adr`](./adr/)                         | Criar, listar, exibir e atualizar ADRs                   |

--- a/docs/src/content/docs/pt-br/reference/cli/init.mdx
+++ b/docs/src/content/docs/pt-br/reference/cli/init.mdx
@@ -1,9 +1,9 @@
 ---
 title: archgate init
-description: "Inicializa a governança do Archgate no projeto atual."
+description: "Configura o linting e a aplicação de regras do Archgate no projeto atual."
 ---
 
-Inicializa a governança do Archgate no projeto atual.
+Configura o linting e a aplicação de regras do Archgate no projeto atual.
 
 ```bash
 archgate init [options]

--- a/docs/src/content/docs/reference/cli/index.mdx
+++ b/docs/src/content/docs/reference/cli/index.mdx
@@ -22,7 +22,7 @@ archgate check --help
 | Command                                          | Description                                           |
 | ------------------------------------------------ | ----------------------------------------------------- |
 | [`archgate login`](./login/)                     | Authenticate with GitHub                              |
-| [`archgate init`](./init/)                       | Initialize Archgate governance                        |
+| [`archgate init`](./init/)                       | Set up linting and rules enforcement                  |
 | [`archgate plugin`](./plugin/)                   | Manage editor plugins                                 |
 | [`archgate check`](./check/)                     | Run ADR compliance checks                             |
 | [`archgate adr`](./adr/)                         | Create, list, show, and update ADRs                   |

--- a/docs/src/content/docs/reference/cli/init.mdx
+++ b/docs/src/content/docs/reference/cli/init.mdx
@@ -1,9 +1,9 @@
 ---
 title: archgate init
-description: "Initialize Archgate governance in the current project."
+description: "Set up Archgate linting and rules enforcement in the current project."
 ---
 
-Initialize Archgate governance in the current project.
+Set up Archgate linting and rules enforcement in the current project.
 
 ```bash
 archgate init [options]


### PR DESCRIPTION
## Summary

Implements PR 1 of the positioning migration plan (linting-and-guardrails positioning adopted 2026-06-09, canonical reference: internal `marketing/positioning.md`). Moves lead-position copy (frontmatter descriptions, opening sentences, CLI command table rows, ROADMAP vision) off governance-first wording to the linting/guardrails vocabulary. Body-text supporting uses of governance are intentionally left alone.

## Changes

EN source:
- `docs/src/content/docs/reference/cli/init.mdx`: description and opening sentence now read "Set up Archgate linting and rules enforcement in the current project."
- `docs/src/content/docs/concepts/domains.mdx`: description tail "...for targeted governance" -> "...to scope and enforce rules"
- `docs/src/content/docs/examples/common-rule-patterns.mdx`: description -> "Copy-paste rule patterns for enforcing common checks: ..."
- `docs/src/content/docs/reference/cli/index.mdx`: init row -> "Set up linting and rules enforcement"
- `ROADMAP.md` Vision: "standard governance layer" -> "standard linting and guardrails"

Locales: the same four docs edits mirrored in `pt-br/` and `nb/`.

Build artifact: `docs/public/llms-full.txt` regenerated by the docs build.

## Verification

- Safety sweep over `docs/src/content` and root `*.md` for banned lead phrases ("governance layer", "governance platform", "more than a linter", "plataforma de governança", "camada de governança", "styringsplattform"): no remaining hits
- `archgate check`: 39/39 pass, 0 warnings (i18n parity and translation-drift rules included)
- `archgate review-context`: clean
- `bun run build` in `docs/`: passed, 169 pages built

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project vision and core messaging to describe Archgate as focused on linting and rules enforcement
  * Refreshed CLI command descriptions for `archgate init` across all language versions to reference linting and rule enforcement
  * Clarified ADR organization and domain grouping language to emphasize scoping and enforcing rules
  * Adjusted common rule patterns page descriptions for copy-paste rule patterns
<!-- end of auto-generated comment: release notes by coderabbit.ai -->