### PR TITLE
fix(engine): re-validate expanded brace patterns against safeGlob

### DIFF
--- a/src/engine/runner.ts
+++ b/src/engine/runner.ts
@@ -159,6 +159,7 @@ function createRuleContext(
       const patterns = expandBracePattern(pattern);
       const seen = new Set<string>();
       for (const p of patterns) {
+        safeGlob(p);
         const g = new Bun.Glob(p);
         // dot: true so rules can target dot-prefixed paths like `.github/`,
         // `.husky/`, `.vscode/` — first-class source dirs in code repos.
@@ -205,6 +206,7 @@ function createRuleContext(
       // See https://github.com/archgate/cli/issues/222.
       const seen = new Set<string>();
       for (const p of globs) {
+        safeGlob(p);
         const g = new Bun.Glob(p);
         // oxlint-disable-next-line no-await-in-loop -- sequential scan per expanded brace alternative
         for await (const file of g.scan({ cwd: projectRoot, dot: true })) {

--- a/tests/engine/runner-security.test.ts
+++ b/tests/engine/runner-security.test.ts
@@ -179,4 +179,23 @@ describe("runChecks path sandboxing", () => {
     const result = await runChecks(tempDir, [loaded]);
     expect(result.results[0].error).toContain("escapes project root");
   });
+
+  test("blocks absolute paths produced by brace expansion", async () => {
+    const loaded = makeLoadedAdr(
+      {},
+      {
+        rules: {
+          "brace-abs-glob": {
+            description: "Attempt absolute path via brace expansion",
+            async check(ctx) {
+              await ctx.glob("{/etc/passwd,src/a.ts}");
+            },
+          },
+        },
+      }
+    );
+
+    const result = await runChecks(tempDir, [loaded]);
+    expect(result.results[0].error).toContain("access denied");
+  });
 });

--- a/tests/engine/runner-security.test.ts
+++ b/tests/engine/runner-security.test.ts
@@ -198,4 +198,24 @@ describe("runChecks path sandboxing", () => {
     const result = await runChecks(tempDir, [loaded]);
     expect(result.results[0].error).toContain("access denied");
   });
+
+  test("blocks absolute paths produced by brace expansion in grepFiles", async () => {
+    const loaded = makeLoadedAdr(
+      {},
+      {
+        rules: {
+          "brace-abs-grepfiles": {
+            description:
+              "Attempt absolute path via brace expansion in grepFiles",
+            async check(ctx) {
+              await ctx.grepFiles(/./u, "{/etc/passwd,src/a.ts}");
+            },
+          },
+        },
+      }
+    );
+
+    const result = await runChecks(tempDir, [loaded]);
+    expect(result.results[0].error).toContain("access denied");
+  });
 });


### PR DESCRIPTION
## Summary

- `expandBracePattern()` can produce absolute paths that bypass the initial `safeGlob()` check (e.g. `{/etc/passwd,foo}` starts with `{` so `isAbsolute()` returns false, but expands to `/etc/passwd`)
- Add `safeGlob()` validation on each expanded pattern before passing to `Bun.Glob` in both `ctx.glob()` and `ctx.grepFiles()`
- Add security test verifying that absolute paths produced by brace expansion are blocked

Follow-up to #422, addressing [CodeRabbit review feedback](https://github.com/archgate/cli/pull/422#pullrequestreview-4546641646).

## Test plan

- [x] New test: `"blocks absolute paths produced by brace expansion"` in `runner-security.test.ts`
- [x] All existing tests pass (1305 pass, 0 fail)
- [x] `bun run validate` passes (lint, typecheck, format, test, 39/39 ADR rules, knip, build)

https://claude.ai/code/session_01C3VSm9YHmfhZ9kLw2fkLE4