### PR TITLE
fix: handle parse errors in rule scanner and loader gracefully

### DIFF
--- a/src/engine/loader.ts
+++ b/src/engine/loader.ts
@@ -309,7 +309,37 @@ export async function loadRuleAdrs(
       }
 
       // Use file:// URL to handle Windows backslash paths in import().
-      const mod = await import(pathToFileURL(rulesFile).href);
+      let mod: Record<string, unknown>;
+      try {
+        mod = await import(pathToFileURL(rulesFile).href);
+      } catch (err) {
+        // Bun throws AggregateError with "Parse error" for files with syntax
+        // errors that pass the transpiler-based scanner but fail the full
+        // import parser.  Surface the first inner error for a useful message.
+        const msg =
+          err instanceof AggregateError && err.errors.length > 0
+            ? String(err.errors[0])
+            : err instanceof Error
+              ? err.message
+              : String(err);
+        return {
+          type: "blocked",
+          value: {
+            adr,
+            error: `ADR ${adr.frontmatter.id}: failed to import companion rule file — ${msg}`,
+            violations: [
+              {
+                message: `Failed to load rule file: ${msg}`,
+                file: rulesFile,
+                line: 1,
+                column: 0,
+                endLine: 1,
+                endColumn: 0,
+              },
+            ],
+          },
+        };
+      }
       const parsed = RuleSetSchema.safeParse(mod.default);
 
       if (!parsed.success) {

--- a/src/engine/rule-scanner.ts
+++ b/src/engine/rule-scanner.ts
@@ -46,8 +46,45 @@ import { remapViolations, type RawViolation } from "./source-positions";
  */
 export function scanRuleSource(source: string): ScanViolation[] {
   const transpiler = new Bun.Transpiler({ loader: "ts" });
-  const js = transpiler.transformSync(source);
-  const ast = parseModule(js, { next: true, loc: true, module: true });
+  let js: string;
+  try {
+    js = transpiler.transformSync(source);
+  } catch (err) {
+    // Bun.Transpiler throws AggregateError for syntax errors in the source.
+    // Return a single violation pointing at line 1 so the caller can report
+    // the file as blocked rather than crashing.
+    const msg =
+      err instanceof AggregateError && err.errors.length > 0
+        ? String(err.errors[0])
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return [
+      {
+        message: `Parse error: ${msg}`,
+        line: 1,
+        column: 0,
+        endLine: 1,
+        endColumn: 0,
+      },
+    ];
+  }
+
+  let ast: ReturnType<typeof parseModule>;
+  try {
+    ast = parseModule(js, { next: true, loc: true, module: true });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return [
+      {
+        message: `Parse error: ${msg}`,
+        line: 1,
+        column: 0,
+        endLine: 1,
+        endColumn: 0,
+      },
+    ];
+  }
   const rawViolations: RawViolation[] = [];
 
   /** Track how many times each searchText has been seen, to match by occurrence. */
@@ -204,8 +241,42 @@ const IMPORTED_BLOCKED_GLOBALS = new Set(["require", "WebSocket"]);
  */
 export function scanImportedRuleSource(source: string): ScanViolation[] {
   const transpiler = new Bun.Transpiler({ loader: "ts" });
-  const js = transpiler.transformSync(source);
-  const ast = parseModule(js, { next: true, loc: true, module: true });
+  let js: string;
+  try {
+    js = transpiler.transformSync(source);
+  } catch (err) {
+    const msg =
+      err instanceof AggregateError && err.errors.length > 0
+        ? String(err.errors[0])
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return [
+      {
+        message: `Parse error: ${msg}`,
+        line: 1,
+        column: 0,
+        endLine: 1,
+        endColumn: 0,
+      },
+    ];
+  }
+
+  let ast: ReturnType<typeof parseModule>;
+  try {
+    ast = parseModule(js, { next: true, loc: true, module: true });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return [
+      {
+        message: `Parse error: ${msg}`,
+        line: 1,
+        column: 0,
+        endLine: 1,
+        endColumn: 0,
+      },
+    ];
+  }
   const rawViolations: RawViolation[] = [];
 
   const seenCounts = new Map<string, number>();

--- a/tests/engine/loader.test.ts
+++ b/tests/engine/loader.test.ts
@@ -205,6 +205,32 @@ export default {
     expect(blocked.value.violations).toHaveLength(2);
   });
 
+  test("returns blocked result when .rules.ts has syntax errors", async () => {
+    const adrsDir = join(tempDir, ".archgate", "adrs");
+    copyFileSync(
+      join(fixturesDir, "TEST-001-sample.md"),
+      join(adrsDir, "TEST-001-sample.md")
+    );
+    writeFileSync(
+      join(adrsDir, "TEST-001-sample.rules.ts"),
+      `/// <reference path="../rules.d.ts" />
+
+export default { invalid syntax here !!! } satisfies RuleSet;
+`
+    );
+
+    const results = await loadRuleAdrs(tempDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].type).toBe("blocked");
+    const blocked = results[0] as Extract<
+      (typeof results)[0],
+      { type: "blocked" }
+    >;
+    expect(blocked.value.error).toContain("security scanner");
+    expect(blocked.value.violations.length).toBeGreaterThanOrEqual(1);
+    expect(blocked.value.violations[0].message).toContain("Parse error");
+  });
+
   test("loads ADRs from custom directory configured in config.json", async () => {
     // Create a custom ADR directory outside .archgate/
     const customAdrsDir = join(tempDir, "docs", "adrs");

--- a/tests/engine/rule-scanner.test.ts
+++ b/tests/engine/rule-scanner.test.ts
@@ -254,6 +254,23 @@ describe("scanRuleSource", () => {
     });
   });
 
+  describe("parse error handling", () => {
+    test("returns violation instead of throwing for unparseable source", () => {
+      const source = `export default { invalid syntax here !!! }`;
+      const violations = scanRuleSource(source);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain("Parse error");
+      expect(violations[0].line).toBe(1);
+    });
+
+    test("returns violation for completely broken TypeScript", () => {
+      const source = `<<<<<<< HEAD\nconst x = 1;\n=======\nconst x = 2;\n>>>>>>> branch`;
+      const violations = scanRuleSource(source);
+      expect(violations.length).toBeGreaterThanOrEqual(1);
+      expect(violations[0].message).toContain("Parse error");
+    });
+  });
+
   // Position remapping tests are in rule-scanner-positions.test.ts
 });
 
@@ -400,6 +417,15 @@ export default {
 `;
       const violations = scanImportedRuleSource(source);
       expect(violations).toHaveLength(0);
+    });
+  });
+
+  describe("parse error handling", () => {
+    test("returns violation instead of throwing for unparseable source", () => {
+      const source = `export default { invalid syntax here !!! }`;
+      const violations = scanImportedRuleSource(source);
+      expect(violations.length).toBeGreaterThanOrEqual(1);
+      expect(violations[0].message).toContain("Parse error");
     });
   });
 


### PR DESCRIPTION
## Summary

- Fix unhandled `AggregateError: Parse error` crash during `archgate check` when user `.rules.ts` files contain syntax errors (Sentry #130690158)
- Wrap `Bun.Transpiler.transformSync()`, `meriyah.parseModule()`, and dynamic `import()` in try-catch blocks in the rule scanner and loader
- Return structured `blocked` results with actionable violation messages instead of crashing

## Context

When a `.rules.ts` file has a syntax error, `Bun.Transpiler.transformSync()` throws an `AggregateError` with `BuildMessage` inner errors. This was unhandled in both `scanRuleSource()` and `scanImportedRuleSource()`. Similarly, the `import()` call in `loadRuleAdrs()` was unhandled — if a file somehow passes the scanner but fails at import time, it would also crash.

The fix ensures all three error paths return violations pointing at line 1 of the offending file, surfacing the first inner error message for diagnostic clarity.

## Test plan

- [x] New tests: `scanRuleSource` returns violation for unparseable source (2 cases)
- [x] New tests: `scanImportedRuleSource` returns violation for unparseable source
- [x] New test: `loadRuleAdrs` returns blocked result for `.rules.ts` with syntax errors
- [x] All 1310 existing tests pass
- [x] `bun run validate` passes (lint, typecheck, format, test, ADR check, build)