### PR TITLE
chore: migrate studies.archgate.dev links to docs.archgate.dev

### DIFF
--- a/docs/src/content/docs/nb/studies/sentry-pr-review-friction-and-adr-pack.mdx
+++ b/docs/src/content/docs/nb/studies/sentry-pr-review-friction-and-adr-pack.mdx
@@ -20,6 +20,6 @@ På tvers av **500 sammenslåtte PR-er**, **500 lukket-uten-sammenslåing PR-er*
 
 Den komplette studien -- metodikk, grunnlinjemetrikker, friksjonskart, temaanalyse og ADR-forslag -- er publisert på:
 
-**[studies.archgate.dev/studies/sentry-pr-review-friction](https://studies.archgate.dev/studies/sentry-pr-review-friction/)**
+**[docs.archgate.dev/studies/sentry-pr-review-friction](https://docs.archgate.dev/studies/sentry-pr-review-friction/)**
 
 Kildekode og dataartefakter finnes i [`archgate/studies`](https://github.com/archgate/studies/tree/main/studies/sentry-pr-review-friction).

--- a/docs/src/content/docs/pt-br/studies/sentry-pr-review-friction-and-adr-pack.mdx
+++ b/docs/src/content/docs/pt-br/studies/sentry-pr-review-friction-and-adr-pack.mdx
@@ -15,11 +15,11 @@ O objetivo não é eliminar revisão humana, e sim levar debates repetitivos e p
 
 Leia a publicação canônica (metodologia, métricas, índice de ADRs) em:
 
-- [**Visão geral: atrito em PRs do Sentry**](https://studies.archgate.dev/studies/sentry-pr-review-friction/), mesmo conteúdo que as páginas narrativas em [`archgate/studies`](https://github.com/archgate/studies)
+- [**Visão geral: atrito em PRs do Sentry**](https://docs.archgate.dev/studies/sentry-pr-review-friction/), mesmo conteúdo que as páginas narrativas em [`archgate/studies`](https://github.com/archgate/studies)
 
 ## Escopo e método
 
-Alinhado à [metodologia](https://studies.archgate.dev/studies/sentry-pr-review-friction/methodology/) do estudo publicado:
+Alinhado à [metodologia](https://docs.archgate.dev/studies/sentry-pr-review-friction/methodology/) do estudo publicado:
 
 | Conjunto de dados               | Contagem                                           |
 | ------------------------------- | -------------------------------------------------- |
@@ -52,11 +52,11 @@ Tudo abaixo está auditado em **[`archgate/studies`](https://github.com/archgate
 
 ## Achados de linha de base (resumo)
 
-Os números acompanham a **[visão geral publicada](https://studies.archgate.dev/studies/sentry-pr-review-friction/)** (janela de 90 dias terminando em abril de 2026). Tabelas completas em [métricas de linha de base](https://studies.archgate.dev/studies/sentry-pr-review-friction/baseline/).
+Os números acompanham a **[visão geral publicada](https://docs.archgate.dev/studies/sentry-pr-review-friction/)** (janela de 90 dias terminando em abril de 2026). Tabelas completas em [métricas de linha de base](https://docs.archgate.dev/studies/sentry-pr-review-friction/baseline/).
 
 ### Ressalva de cobertura
 
-Só PRs mesclados podem omitir **ambiguidade de decisão**: PRs com muita discussão fechados sem merge e PRs abertos **estagnados**. O estudo publicado inclui coortes fechadas e abertas; veja [PRs abandonados](https://studies.archgate.dev/studies/sentry-pr-review-friction/abandoned/).
+Só PRs mesclados podem omitir **ambiguidade de decisão**: PRs com muita discussão fechados sem merge e PRs abertos **estagnados**. O estudo publicado inclui coortes fechadas e abertas; veja [PRs abandonados](https://docs.archgate.dev/studies/sentry-pr-review-friction/abandoned/).
 
 ### Perfil de atrito no repositório
 
@@ -74,18 +74,18 @@ PRs grandes são minoria, mas dominam o custo de review.
 
 ### Domínios, escopo e temas
 
-O estudo detalha atrito por domínio, escopo do título do commit (`feat` vs `fix`, etc.) e temas de discussão a partir de **604 comentários não-bot** em **60** PRs de alto atrito. Veja [temas](https://studies.archgate.dev/studies/sentry-pr-review-friction/themes/) e [mapa de atrito](https://studies.archgate.dev/studies/sentry-pr-review-friction/friction-map/).
+O estudo detalha atrito por domínio, escopo do título do commit (`feat` vs `fix`, etc.) e temas de discussão a partir de **604 comentários não-bot** em **60** PRs de alto atrito. Veja [temas](https://docs.archgate.dev/studies/sentry-pr-review-friction/themes/) e [mapa de atrito](https://docs.archgate.dev/studies/sentry-pr-review-friction/friction-map/).
 
 ## PRs abandonados e estagnados
 
-A análise inclui **500** PRs fechados sem merge e **251** PRs abertos (estagnação 14+ / 30+ dias), conforme a [metodologia](https://studies.archgate.dev/studies/sentry-pr-review-friction/methodology/).
+A análise inclui **500** PRs fechados sem merge e **251** PRs abertos (estagnação 14+ / 30+ dias), conforme a [metodologia](https://docs.archgate.dev/studies/sentry-pr-review-friction/methodology/).
 
 Na visão geral publicada:
 
 - **12** PRs fechados sem merge (**2.4%**) tinham **≥10** itens de discussão; esses casos **abandonados** mostram **~2×** TTM mediano e **~2.5×** eventos de review vs PRs mesclados de alto atrito
 - **92** PRs abertos estagnados há **14+** dias; **33** há **30+** dias (exemplo estagnado mais discutido: **55** eventos de review)
 
-Se você mede só PRs mesclados, a governança pode parecer mais saudável do que é. Trate coortes fechadas sem merge e abertas estagnadas como métricas de primeira classe. Detalhes em [**PRs abandonados**](https://studies.archgate.dev/studies/sentry-pr-review-friction/abandoned/).
+Se você mede só PRs mesclados, a governança pode parecer mais saudável do que é. Trate coortes fechadas sem merge e abertas estagnadas como métricas de primeira classe. Detalhes em [**PRs abandonados**](https://docs.archgate.dev/studies/sentry-pr-review-friction/abandoned/).
 
 ## Exemplos de PRs de alto atrito
 
@@ -118,7 +118,7 @@ São exatamente decisões de equipe que ADRs podem codificar e regras podem faze
 
 ## Pacote de ADRs proposto para o Sentry
 
-O conjunto fundamentado em evidências (com ADRs em Markdown, arquivos `.rules.ts` e artefatos de lint) está indexado no site do estudo em [**Propostas de ADR**](https://studies.archgate.dev/studies/sentry-pr-review-friction/adr-proposals/) e em [`archgate/studies` em `proposed-adrs/`](https://github.com/archgate/studies/tree/main/studies/sentry-pr-review-friction/proposed-adrs).
+O conjunto fundamentado em evidências (com ADRs em Markdown, arquivos `.rules.ts` e artefatos de lint) está indexado no site do estudo em [**Propostas de ADR**](https://docs.archgate.dev/studies/sentry-pr-review-friction/adr-proposals/) e em [`archgate/studies` em `proposed-adrs/`](https://github.com/archgate/studies/tree/main/studies/sentry-pr-review-friction/proposed-adrs).
 
 A narrativa abaixo está priorizada pela redução esperada de atrito em review.
 

--- a/docs/src/content/docs/studies/sentry-pr-review-friction-and-adr-pack.mdx
+++ b/docs/src/content/docs/studies/sentry-pr-review-friction-and-adr-pack.mdx
@@ -20,6 +20,6 @@ Across **500 merged PRs**, **500 closed-unmerged PRs**, and **251 open PRs** ove
 
 The complete study -- methodology, baseline metrics, friction maps, theme analysis, and ADR proposals -- is published at:
 
-**[studies.archgate.dev/studies/sentry-pr-review-friction](https://studies.archgate.dev/studies/sentry-pr-review-friction/)**
+**[docs.archgate.dev/studies/sentry-pr-review-friction](https://docs.archgate.dev/studies/sentry-pr-review-friction/)**
 
 Source code and data artifacts are in [`archgate/studies`](https://github.com/archgate/studies/tree/main/studies/sentry-pr-review-friction).


### PR DESCRIPTION
## Summary

- Replace all `studies.archgate.dev` URLs with `docs.archgate.dev` across 3 locale files (en, pt-br, nb)
- The `studies.archgate.dev` subdomain has been shut down; content now lives at `docs.archgate.dev/studies/`
- A 301 redirect is in place for existing bookmarks

## Test plan

- [ ] Verify links in the study pages resolve correctly after merge