### PR TITLE
fix(release): cap breaking-change bumps to minor while pre-1.0

### DIFF
--- a/.claude/agent-memory/archgate-developer/MEMORY.md
+++ b/.claude/agent-memory/archgate-developer/MEMORY.md
@@ -14,6 +14,7 @@ Skipping steps 2 or 3 is a workflow violation. The user should NEVER have to inv
 
 - **Minimum version** (`>=1.2.21`): Enforced in `src/cli.ts`, documented in CLAUDE.md "Technology Stack". This is the user-facing requirement.
 - **Pinned version** (`1.3.14`): Set in `.prototools`, referenced in ADR risk sections (ARCH-005, ARCH-006) and CLAUDE.md "Toolchain" section. This is the dev toolchain version.
+- **Pre-1.0 release bump policy**: breaking changes bump MINOR, not major — enforced by the `getNextVersion` cap in `.simple-release.js`. v1.0.0 must be an explicit decision (force via the `version` bump option), never an automatic consequence of a `feat!` commit.
 - These are intentionally different. When upgrading the pinned version, update `.prototools` + ADR risk sections + CLAUDE.md toolchain. Do NOT change the minimum unless a new Bun API is required.
 
 ## Git Workflow

--- a/.simple-release.js
+++ b/.simple-release.js
@@ -3,6 +3,36 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { NpmProject } from "@simple-release/npm";
 
 class ArchgateProject extends NpmProject {
+  /**
+   * Pre-1.0 semver policy: breaking changes bump the MINOR version, not
+   * the major. The project ships no support guarantees yet, so v1.0.0
+   * must be an explicit decision — force it via the `version` (or `as`)
+   * bump option when the time comes — never an automatic consequence of
+   * a `feat!`/BREAKING CHANGE commit landing on main.
+   *
+   * `bump()` derives its version from this method, so capping here keeps
+   * the manifest writes, changelog, release PR title, and tag consistent.
+   */
+  async getNextVersion(options) {
+    const next = await super.getNextVersion(options);
+
+    // Respect explicit overrides and no-op results.
+    if (!next || options?.version || options?.as) {
+      return next;
+    }
+
+    const current = await this.manifest.getVersion();
+    const isPreMajor = current?.startsWith("0.");
+    const bumpsToMajor = !next.startsWith("0.");
+
+    if (isPreMajor && bumpsToMajor) {
+      const minor = Number(current.split(".")[1] ?? 0);
+      return `0.${minor + 1}.0`;
+    }
+
+    return next;
+  }
+
   async bump(options) {
     const result = await super.bump(options);
 


### PR DESCRIPTION
## Problem

The session-context breaking changes (#446) made simple-release propose **v1.0.0** (release PR #440). We are not ready to publish 1.0.0 — the project still ships no support guarantees. Pre-1.0, breaking changes should produce a **minor** bump (0.46.0).

## Fix

Override `getNextVersion` in `.simple-release.js`: when the current version is `0.x` and the conventional-commit computation yields a major bump, return the next minor instead. `bump()` derives its version from `getNextVersion`, so the manifest writes, changelog, release-PR title, and tag all stay consistent from the single cap.

Explicit `version`/`as` bump options bypass the cap, so v1.0.0 remains available as a deliberate, forced decision.

## Verification

Dry-run against the live git history (which contains the `feat!` commits):

| | computed next version |
|---|---|
| stock `NpmProject` | `1.0.0` |
| capped `ArchgateProject` | `0.46.0` |

Lint, typecheck, format, and `archgate check` (39/39) green.

## After merge

The push to `main` re-triggers the release `pull-request` workflow, which updates release PR #440 in place from 1.0.0 to 0.46.0 (title, changelog, version files, shim versions). **Do not merge #440 before this lands.**

https://claude.ai/code/session_01SGjSjrywTnZDcUqgHWGrTj